### PR TITLE
Remove play toggle command

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -78,7 +78,7 @@ unityctl logs -f                # Stream logs
 unityctl logs clear             # Clear log history
 unityctl scene list             # List scenes
 unityctl scene load <path>      # Load a scene
-unityctl play enter/exit/toggle # Control play mode
+unityctl play enter/exit        # Control play mode
 unityctl play status            # Get play mode status
 unityctl asset import <path>    # Import an asset
 unityctl asset refresh          # Refresh assets (triggers compilation if needed)
@@ -105,7 +105,7 @@ unityctl asset refresh          # Refresh assets (triggers compilation if needed
 **Commands Handled:**
 - `scene.list` - List build settings or all scenes
 - `scene.load` - Load scene (single/additive)
-- `play.enter/exit/toggle/status` - Play mode control
+- `play.enter/exit/status` - Play mode control
 - `asset.import` - Asset import
 - `asset.refresh` - Refresh assets (triggers compilation)
 
@@ -312,7 +312,7 @@ The implementation includes a test Unity project at `unity-project/` with the Un
 - Read console and editor logs
 - Trigger asset import and script compilation
 - List and load scenes
-- Enter / exit / toggle play mode
+- Enter / exit play mode
 - Stable connection across domain reloads
 - Multi-agent support
 - Project isolation
@@ -321,7 +321,7 @@ The implementation includes a test Unity project at `unity-project/` with the Un
 ✅ All wire protocol commands implemented:
 - asset.import, asset.reimportAll (not exposed in CLI yet), asset.refresh
 - scene.list, scene.load
-- play.enter, play.exit, play.toggle, play.status
+- play.enter, play.exit, play.status
 
 ✅ All events implemented:
 - log

--- a/UnityCtl.Cli/PlayCommands.cs
+++ b/UnityCtl.Cli/PlayCommands.cs
@@ -23,11 +23,6 @@ public static class PlayCommands
         exitCommand.SetHandler(async (InvocationContext context) =>
             await HandlePlayCommand(context, UnityCtlCommands.PlayExit));
 
-        // play toggle
-        var toggleCommand = new Command("toggle", "Toggle play mode");
-        toggleCommand.SetHandler(async (InvocationContext context) =>
-            await HandlePlayCommand(context, UnityCtlCommands.PlayToggle));
-
         // play status
         var statusCommand = new Command("status", "Get play mode status");
         statusCommand.SetHandler(async (InvocationContext context) =>
@@ -35,7 +30,6 @@ public static class PlayCommands
 
         playCommand.AddCommand(enterCommand);
         playCommand.AddCommand(exitCommand);
-        playCommand.AddCommand(toggleCommand);
         playCommand.AddCommand(statusCommand);
         return playCommand;
     }

--- a/UnityCtl.Protocol/Constants.cs
+++ b/UnityCtl.Protocol/Constants.cs
@@ -14,7 +14,6 @@ public static class UnityCtlCommands
     // Play mode
     public const string PlayEnter = "play.enter";
     public const string PlayExit = "play.exit";
-    public const string PlayToggle = "play.toggle";
     public const string PlayStatus = "play.status";
 
     // Menu items

--- a/UnityCtl.UnityPackage/Editor/UnityCtlClient.cs
+++ b/UnityCtl.UnityPackage/Editor/UnityCtlClient.cs
@@ -427,14 +427,6 @@ namespace UnityCtl
                         }
                         break;
 
-                    case UnityCtlCommands.PlayToggle:
-                        EditorApplication.isPlaying = !EditorApplication.isPlaying;
-                        result = new PlayModeResult
-                        {
-                            State = EditorApplication.isPlaying ? PlayModeState.Playing : PlayModeState.Stopped
-                        };
-                        break;
-
                     case UnityCtlCommands.PlayStatus:
                         result = new PlayModeResult
                         {


### PR DESCRIPTION
The toggle command adds ambiguity compared to explicit enter/exit
commands. Removed from protocol constants, CLI, Unity plugin handler,
and documentation.

https://claude.ai/code/session_01Lr2f9VNboACRi24Dv7Ghf3