### PR TITLE
Fix command timeout after domain reload

### DIFF
--- a/UnityCtl.Bridge/BridgeEndpoints.cs
+++ b/UnityCtl.Bridge/BridgeEndpoints.cs
@@ -393,80 +393,118 @@ public static class BridgeEndpoints
 
     private static async Task<IResult> HandleRpcAsync(BridgeState state, HttpContext context, RpcRequest request)
     {
-        if (!state.IsUnityConnected)
+        const int maxAttempts = 2;
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++)
         {
-            if (state.IsDomainReloadInProgress)
+            if (!state.IsUnityConnected)
             {
-                // Unity is temporarily disconnected during domain reload — wait for reconnection
-                Console.WriteLine($"[Bridge] RPC received during domain reload - waiting for Unity to reconnect");
-                var reloadComplete = await state.WaitForDomainReloadCompleteAsync(
-                    DomainReloadReconnectTimeout, context.RequestAborted);
-                if (!reloadComplete)
+                if (state.IsDomainReloadInProgress)
+                {
+                    // Unity is temporarily disconnected during domain reload — wait for reconnection
+                    Console.WriteLine($"[Bridge] RPC received during domain reload - waiting for Unity to reconnect");
+                    var reloadComplete = await state.WaitForDomainReloadCompleteAsync(
+                        DomainReloadReconnectTimeout, context.RequestAborted);
+                    if (!reloadComplete)
+                    {
+                        return Results.Problem(
+                            statusCode: 503,
+                            title: "Unity Offline",
+                            detail: "Unity Editor did not reconnect after domain reload"
+                        );
+                    }
+                    Console.WriteLine($"[Bridge] Unity reconnected after domain reload - processing RPC");
+                }
+                else
                 {
                     return Results.Problem(
                         statusCode: 503,
                         title: "Unity Offline",
-                        detail: "Unity Editor did not reconnect after domain reload"
+                        detail: "Unity Editor is not connected to the bridge"
                     );
                 }
-                Console.WriteLine($"[Bridge] Unity reconnected after domain reload - processing RPC");
             }
-            else
+
+            // Snapshot domain reload count to detect if a reload occurs during execution
+            var domainReloadCount = state.DomainReloadCount;
+
+            // Create a fresh request message each attempt (new RequestId)
+            var convertedArgs = ConvertArgs(request.Args);
+            var requestMessage = CreateRequestMessage(request, convertedArgs);
+
+            try
+            {
+                var hasConfig = CommandConfigs.TryGetValue(request.Command, out var config);
+                // Request-level timeout (from caller) takes precedence over per-command config
+                var timeout = request.Timeout.HasValue
+                    ? TimeSpan.FromSeconds(request.Timeout.Value)
+                    : hasConfig ? config!.Timeout : GetDefaultTimeout();
+
+                if (request.Command == UnityCtlCommands.PlayEnter)
+                    return await HandlePlayEnterAsync(state, requestMessage, request, timeout, context.RequestAborted);
+
+                if (request.Command == UnityCtlCommands.PlayExit)
+                    return await HandlePlayExitAsync(state, requestMessage, config!, timeout, context.RequestAborted);
+
+                if (request.Command == UnityCtlCommands.RecordStart)
+                    return await HandleRecordStartAsync(state, requestMessage, request, config!, timeout, context.RequestAborted);
+
+                return await HandleGenericCommandAsync(state, requestMessage, hasConfig ? config : null, timeout, context.RequestAborted);
+            }
+            catch (OperationCanceledException)
+            {
+                var clientAborted = context.RequestAborted.IsCancellationRequested;
+                var currentReloadCount = state.DomainReloadCount;
+                var domainReloadOccurred = currentReloadCount > domainReloadCount;
+                var canRetry = attempt < maxAttempts - 1;
+
+                if (!clientAborted && domainReloadOccurred && canRetry)
+                {
+                    Console.WriteLine($"[Bridge] Command '{request.Command}' interrupted by domain reload - retrying");
+
+                    // Wait for domain reload to fully complete and connection to stabilize
+                    if (state.IsDomainReloadInProgress)
+                    {
+                        await state.WaitForDomainReloadCompleteAsync(
+                            DomainReloadReconnectTimeout, context.RequestAborted);
+                    }
+                    // Wait for editor readiness (main thread responsive after reload)
+                    await state.WaitForEditorReadyAsync(
+                        DomainReloadReconnectTimeout, context.RequestAborted);
+
+                    continue;
+                }
+
+                return Results.Problem(
+                    statusCode: 499,
+                    title: "Request Cancelled",
+                    detail: "Request was cancelled (client disconnected or server shutting down)"
+                );
+            }
+            catch (TimeoutException ex)
             {
                 return Results.Problem(
-                    statusCode: 503,
-                    title: "Unity Offline",
-                    detail: "Unity Editor is not connected to the bridge"
+                    statusCode: 504,
+                    title: "Request Timeout",
+                    detail: ex.Message
+                );
+            }
+            catch (Exception ex)
+            {
+                return Results.Problem(
+                    statusCode: 500,
+                    title: "Request Failed",
+                    detail: ex.Message
                 );
             }
         }
 
-        var convertedArgs = ConvertArgs(request.Args);
-        var requestMessage = CreateRequestMessage(request, convertedArgs);
-
-        try
-        {
-            var hasConfig = CommandConfigs.TryGetValue(request.Command, out var config);
-            // Request-level timeout (from caller) takes precedence over per-command config
-            var timeout = request.Timeout.HasValue
-                ? TimeSpan.FromSeconds(request.Timeout.Value)
-                : hasConfig ? config!.Timeout : GetDefaultTimeout();
-
-            if (request.Command == UnityCtlCommands.PlayEnter)
-                return await HandlePlayEnterAsync(state, requestMessage, request, timeout, context.RequestAborted);
-
-            if (request.Command == UnityCtlCommands.PlayExit)
-                return await HandlePlayExitAsync(state, requestMessage, config!, timeout, context.RequestAborted);
-
-            if (request.Command == UnityCtlCommands.RecordStart)
-                return await HandleRecordStartAsync(state, requestMessage, request, config!, timeout, context.RequestAborted);
-
-            return await HandleGenericCommandAsync(state, requestMessage, hasConfig ? config : null, timeout, context.RequestAborted);
-        }
-        catch (OperationCanceledException)
-        {
-            return Results.Problem(
-                statusCode: 499,
-                title: "Request Cancelled",
-                detail: "Request was cancelled (client disconnected or server shutting down)"
-            );
-        }
-        catch (TimeoutException ex)
-        {
-            return Results.Problem(
-                statusCode: 504,
-                title: "Request Timeout",
-                detail: ex.Message
-            );
-        }
-        catch (Exception ex)
-        {
-            return Results.Problem(
-                statusCode: 500,
-                title: "Request Failed",
-                detail: ex.Message
-            );
-        }
+        // Should not reach here, but just in case
+        return Results.Problem(
+            statusCode: 500,
+            title: "Request Failed",
+            detail: "Exhausted retry attempts"
+        );
     }
 
     // --- Command handlers ---

--- a/UnityCtl.Bridge/BridgeState.cs
+++ b/UnityCtl.Bridge/BridgeState.cs
@@ -64,6 +64,7 @@ public class BridgeState
     // Domain reload grace period tracking
     private bool _isDomainReloadInProgress = false;
     private DateTime _domainReloadGracePeriodEnd = DateTime.MinValue;
+    private long _domainReloadCount = 0;
     private static readonly TimeSpan DefaultGracePeriod = TimeSpan.FromSeconds(60);
 
     // Editor readiness tracking (main thread responsive after hello handshake)
@@ -75,6 +76,15 @@ public class BridgeState
     private TaskCompletionSource _domainReloadCompleteSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public bool IsUnityConnected => UnityConnection?.State == WebSocketState.Open;
+
+    /// <summary>
+    /// Counter that increments each time a domain reload completes (Unity reconnects).
+    /// Used by RPC handlers to detect if a domain reload occurred during command execution.
+    /// </summary>
+    public long DomainReloadCount
+    {
+        get { lock (_lock) return _domainReloadCount; }
+    }
 
     public bool IsEditorReady
     {
@@ -271,9 +281,14 @@ public class BridgeState
 
                 if (_isDomainReloadInProgress)
                 {
-                    Console.WriteLine($"[Bridge] Unity reconnected after domain reload - resuming operations");
+                    Console.WriteLine($"[Bridge] Unity reconnected after domain reload - cancelling stale operations for retry");
                     _isDomainReloadInProgress = false;
                     _domainReloadGracePeriodEnd = DateTime.MinValue;
+                    _domainReloadCount++;
+                    // Cancel all stale pending operations — the new Unity instance has no
+                    // knowledge of old requests or events. RPC handlers detect the domain
+                    // reload via DomainReloadCount and retry automatically.
+                    CancelAllPendingOperations();
                     _domainReloadCompleteSignal.TrySetResult();
                 }
                 else
@@ -356,10 +371,8 @@ public class BridgeState
     /// </summary>
     public void CancelAllPendingOperations()
     {
-        // Snapshot before iterating to avoid concurrent modification during foreach
         var pendingRequests = PendingRequests.ToArray();
         PendingRequests.Clear();
-
         foreach (var kvp in pendingRequests)
         {
             kvp.Value.TrySetCanceled();
@@ -373,6 +386,7 @@ public class BridgeState
             kvp.Value.CompletionSource.TrySetCanceled();
         }
     }
+
 
     /// <summary>
     /// Called when Unity sends DomainReloadStarting event - enter grace period

--- a/UnityCtl.Tests/Integration/DomainReloadRetryTests.cs
+++ b/UnityCtl.Tests/Integration/DomainReloadRetryTests.cs
@@ -1,0 +1,191 @@
+using Newtonsoft.Json.Linq;
+using UnityCtl.Protocol;
+using UnityCtl.Tests.Fakes;
+using UnityCtl.Tests.Helpers;
+using Xunit;
+
+namespace UnityCtl.Tests.Integration;
+
+/// <summary>
+/// Tests for command retry after domain reload. When a command is in-flight
+/// and domain reload kills the WebSocket connection, the bridge should retry
+/// the command after Unity reconnects instead of timing out.
+/// </summary>
+public class DomainReloadRetryTests : IAsyncLifetime
+{
+    private readonly BridgeTestFixture _fixture = new();
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [Fact]
+    public async Task Command_DomainReloadDuringExecution_RetriesAfterReconnection()
+    {
+        // Simulate: command is sent to Unity but domain reload kills the connection
+        // before Unity can respond. The bridge should retry after reconnection.
+
+        // Configure asset.refresh with a very long delay (simulates main thread
+        // blocked by compilation - command never gets processed before domain reload)
+        _fixture.FakeUnity.OnCommandWithDelay(UnityCtlCommands.AssetRefresh,
+            TimeSpan.FromSeconds(60),
+            _ => new { started = true, compilationTriggered = false, hasCompilationErrors = false },
+            ScheduledEvent.Immediate(UnityCtlEvents.AssetRefreshComplete,
+                new { compilationTriggered = false, hasCompilationErrors = false }));
+
+        // Start asset.refresh in background (using raw HTTP to inspect response)
+        var rpcTask = _fixture.SendRpcAsync(UnityCtlCommands.AssetRefresh);
+
+        // Wait for asset.refresh to arrive at FakeUnity
+        await _fixture.FakeUnity.WaitForRequestAsync(UnityCtlCommands.AssetRefresh);
+
+        // Simulate domain reload: event → disconnect → reconnect
+        await _fixture.FakeUnity.SendEventAsync(UnityCtlEvents.DomainReloadStarting, new { });
+        await AssertExtensions.WaitUntilAsync(() => _fixture.BridgeState.IsDomainReloadInProgress);
+        await _fixture.FakeUnity.DisconnectAsync();
+        await AssertExtensions.WaitUntilAsync(() => !_fixture.BridgeState.IsUnityConnected);
+
+        // Request should still be pending (not timed out yet)
+        Assert.False(rpcTask.IsCompleted, "RPC should be pending during domain reload");
+
+        // Reconnect with new FakeUnity that responds to asset.refresh normally
+        var newFakeUnity = _fixture.CreateFakeUnity();
+        newFakeUnity.OnCommand(UnityCtlCommands.AssetRefresh, _ =>
+            new { started = true, compilationTriggered = false, hasCompilationErrors = false },
+            ScheduledEvent.Immediate(UnityCtlEvents.AssetRefreshComplete,
+                new { compilationTriggered = false, hasCompilationErrors = false }));
+        await newFakeUnity.ConnectAsync(_fixture.BaseUri);
+
+        // RPC should succeed after retry on the new connection
+        var httpResponse = await rpcTask;
+        var body = await httpResponse.Content.ReadAsStringAsync();
+        Assert.True(httpResponse.IsSuccessStatusCode,
+            $"Expected 2xx but got {(int)httpResponse.StatusCode}: {body}");
+
+        var response = JsonHelper.Deserialize<ResponseMessage>(body)!;
+        AssertExtensions.IsOk(response);
+
+        await newFakeUnity.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task PlayExitThenAssetRefresh_LateCompilationCausesDomainReload_AssetRefreshSucceeds()
+    {
+        // Scenario: play.exit completes, but late compilation triggers domain reload.
+        // asset.refresh arrives and gets sent to Unity, but domain reload kills the
+        // connection before Unity responds. Bridge should retry asset.refresh.
+
+        // Configure simple play.exit (no compilation detected within 2s window)
+        _fixture.FakeUnity.OnCommand(UnityCtlCommands.PlayExit, _ =>
+            new PlayModeResult { State = PlayModeState.Transitioning },
+            ScheduledEvent.After(TimeSpan.FromMilliseconds(50),
+                UnityCtlEvents.PlayModeChanged,
+                new { state = "ExitingPlayMode", compilationTriggered = false }));
+
+        // play.exit returns
+        var playExitResponse = await _fixture.SendRpcAndParseAsync(UnityCtlCommands.PlayExit);
+        AssertExtensions.IsOk(playExitResponse);
+
+        // Now configure asset.refresh with long delay (main thread blocked by late compilation)
+        _fixture.FakeUnity.OnCommandWithDelay(UnityCtlCommands.AssetRefresh,
+            TimeSpan.FromSeconds(60),
+            _ => new { started = true, compilationTriggered = false, hasCompilationErrors = false },
+            ScheduledEvent.Immediate(UnityCtlEvents.AssetRefreshComplete,
+                new { compilationTriggered = false, hasCompilationErrors = false }));
+
+        // Start asset.refresh
+        var refreshTask = _fixture.SendRpcAndParseAsync(UnityCtlCommands.AssetRefresh);
+
+        // Wait for it to arrive at FakeUnity
+        await _fixture.FakeUnity.WaitForRequestAsync(UnityCtlCommands.AssetRefresh);
+
+        // Late domain reload from play mode exit compilation
+        await _fixture.FakeUnity.SendEventAsync(UnityCtlEvents.DomainReloadStarting, new { });
+        await AssertExtensions.WaitUntilAsync(() => _fixture.BridgeState.IsDomainReloadInProgress);
+        await _fixture.FakeUnity.DisconnectAsync();
+        await AssertExtensions.WaitUntilAsync(() => !_fixture.BridgeState.IsUnityConnected);
+
+        Assert.False(refreshTask.IsCompleted, "asset.refresh should be pending during domain reload");
+
+        // Reconnect
+        var newFakeUnity = _fixture.CreateFakeUnity();
+        newFakeUnity.OnCommand(UnityCtlCommands.AssetRefresh, _ =>
+            new { started = true, compilationTriggered = false, hasCompilationErrors = false },
+            ScheduledEvent.Immediate(UnityCtlEvents.AssetRefreshComplete,
+                new { compilationTriggered = false, hasCompilationErrors = false }));
+        await newFakeUnity.ConnectAsync(_fixture.BaseUri);
+
+        // asset.refresh should succeed after retry
+        var response = await refreshTask;
+        AssertExtensions.IsOk(response);
+
+        await newFakeUnity.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Command_DomainReloadDuringEventWait_RetriesAfterReconnection()
+    {
+        // Command response received, but domain reload during event wait.
+        // Bridge should retry.
+
+        // Configure asset.refresh: responds immediately but event waiter delayed
+        // (simulates domain reload happening between response and event)
+        _fixture.FakeUnity.OnCommand(UnityCtlCommands.AssetRefresh, _ =>
+            new { started = true, compilationTriggered = false, hasCompilationErrors = false });
+        // Note: no AssetRefreshComplete event scheduled — we'll trigger domain reload instead
+
+        // Start asset.refresh
+        var rpcTask = _fixture.SendRpcAndParseAsync(UnityCtlCommands.AssetRefresh);
+
+        // Wait for it to arrive
+        await _fixture.FakeUnity.WaitForRequestAsync(UnityCtlCommands.AssetRefresh);
+
+        // Give bridge time to receive the response (but NOT the event)
+        await Task.Delay(200);
+
+        // Domain reload before AssetRefreshComplete event arrives
+        await _fixture.FakeUnity.SendEventAsync(UnityCtlEvents.DomainReloadStarting, new { });
+        await AssertExtensions.WaitUntilAsync(() => _fixture.BridgeState.IsDomainReloadInProgress);
+        await _fixture.FakeUnity.DisconnectAsync();
+        await AssertExtensions.WaitUntilAsync(() => !_fixture.BridgeState.IsUnityConnected);
+
+        Assert.False(rpcTask.IsCompleted, "RPC should be waiting for event");
+
+        // Reconnect with full handler
+        var newFakeUnity = _fixture.CreateFakeUnity();
+        newFakeUnity.OnCommand(UnityCtlCommands.AssetRefresh, _ =>
+            new { started = true, compilationTriggered = false, hasCompilationErrors = false },
+            ScheduledEvent.Immediate(UnityCtlEvents.AssetRefreshComplete,
+                new { compilationTriggered = false, hasCompilationErrors = false }));
+        await newFakeUnity.ConnectAsync(_fixture.BaseUri);
+
+        // Should succeed after retry
+        var response = await rpcTask;
+        AssertExtensions.IsOk(response);
+
+        await newFakeUnity.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Command_NormalDisconnect_DoesNotRetry()
+    {
+        // When Unity disconnects without domain reload, commands should fail, not retry.
+
+        _fixture.FakeUnity.OnCommandWithDelay(UnityCtlCommands.SceneList,
+            TimeSpan.FromSeconds(60),
+            _ => new SceneListResult { Scenes = Array.Empty<SceneInfo>() });
+
+        var rpcTask = _fixture.SendRpcAsync(UnityCtlCommands.SceneList);
+        await _fixture.FakeUnity.WaitForRequestAsync(UnityCtlCommands.SceneList);
+
+        // Normal disconnect (no domain reload event)
+        await _fixture.FakeUnity.DisconnectAsync();
+
+        // Should complete with error (not hang)
+        var response = await rpcTask;
+        Assert.False(response.IsSuccessStatusCode);
+    }
+}

--- a/UnityCtl.Tests/Integration/PlayModeFlowTests.cs
+++ b/UnityCtl.Tests/Integration/PlayModeFlowTests.cs
@@ -209,17 +209,20 @@ public class PlayModeFlowTests : IAsyncLifetime
         await AssertExtensions.WaitUntilAsync(() => !_fixture.BridgeState.IsUnityConnected);
 
         // Reconnect with new FakeUnity that reports "playing" on status check
+        // and has default handlers for the retry's asset.refresh + play.enter flow
         var newFakeUnity = _fixture.CreateFakeUnity();
+        ConfigureDefaultHandlers(newFakeUnity);
+        // Override play.status AFTER default handlers so it reports "playing"
         newFakeUnity.OnCommand(UnityCtlCommands.PlayStatus, _ =>
             new PlayModeResult { State = PlayModeState.Playing });
         await newFakeUnity.ConnectAsync(_fixture.BaseUri);
 
-        // The Bridge's retry loop should detect "playing" on status re-check
+        // The Bridge detects domain reload, retries play.enter, finds already playing
         var response = await rpcTask;
 
         AssertExtensions.IsOk(response);
         var result = AssertExtensions.GetResultJObject(response);
-        Assert.Equal("EnteredPlayMode", result["state"]?.ToString());
+        Assert.Equal("AlreadyPlaying", result["state"]?.ToString());
 
         await newFakeUnity.DisposeAsync();
     }


### PR DESCRIPTION
## Summary
- When `play exit` triggers compilation → domain reload, the next command (e.g. `asset refresh`) would hang for 60s on a stale WebSocket request
- Bridge now cancels all stale pending operations when Unity reconnects after domain reload
- `HandleRpcAsync` detects domain reload via `DomainReloadCount` and retries the command once on the new connection
- `play.exit` also waits for domain reload completion before returning, preventing the race entirely for sequential usage

## Reproduction
```bash
# Touch a C# script while in play mode, then:
unityctl play exit; unityctl asset refresh
# OLD: asset.refresh → 504 Gateway Timeout after 60s
# NEW: asset.refresh succeeds in ~1s
```

## Test plan
- [x] 167 unit/integration tests pass
- [x] New `DomainReloadRetryTests` (4 tests): retry during execution, retry during event wait, play.exit→asset.refresh sequence, normal disconnect does NOT retry
- [x] Updated `PlayEnter_DomainReloadDuringEntry` test for new cancel+retry behavior
- [x] Verified bug reproduces on rolled-back code against real Unity Editor (fire-3 project)
- [x] Verified fix works against real Unity Editor