### PR TITLE
Add plugin system (script + executable)

### DIFF
--- a/.claude/skills/unity-editor/SKILL.md
+++ b/.claude/skills/unity-editor/SKILL.md
@@ -183,3 +183,10 @@ Sample script plugin demonstrating the plugin system
 
 - `unityctl sample-script hello [name] [--loud]`
   Say hello from Unity
+
+### Plugin: sample-exec (executable)
+
+A sample executable plugin that prints connection info. Demonstrates the `unityctl-{name}` naming convention.
+
+- `unityctl sample-exec [args...]`
+  Prints greeting and bridge connection details.

--- a/.claude/skills/unityctl-plugins/SKILL.md
+++ b/.claude/skills/unityctl-plugins/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: unityctl-plugins
+description: Create unityctl plugins. Use when the user wants to create, scaffold, or write a unityctl plugin (script or executable).
+---
+
+# Creating unityctl Plugins
+
+There are two plugin types: **script** (C# running inside Unity) and **executable** (any program on disk).
+
+## Script Plugins
+
+Run C# inside the Unity Editor via the `script.execute` RPC. Best for commands that need Unity APIs.
+
+### Quick start
+
+```bash
+unityctl plugin create my-tool   # scaffolds .unityctl/plugins/my-tool/
+```
+
+### Structure
+
+```
+.unityctl/plugins/my-tool/
+  plugin.json    # manifest
+  hello.cs       # handler script
+```
+
+### plugin.json
+
+```json
+{
+  "name": "my-tool",
+  "version": "1.0.0",
+  "description": "My custom tool",
+  "commands": [
+    {
+      "name": "stats",
+      "description": "Show scene stats",
+      "arguments": [
+        { "name": "scene", "description": "Scene name", "required": false }
+      ],
+      "options": [
+        { "name": "verbose", "type": "bool", "description": "Show details" },
+        { "name": "format", "type": "string", "description": "Output format" }
+      ],
+      "handler": { "type": "script", "file": "stats.cs" }
+    }
+  ],
+  "skill": { "file": "SKILL.md" }
+}
+```
+
+### Handler script
+
+Must define `public class Script` with `public static object Main(string[] args)`. Arguments and options are passed as the `args` array.
+
+```csharp
+using UnityEngine;
+using UnityEditor;
+
+public class Script
+{
+    public static object Main(string[] args)
+    {
+        var count = Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None).Length;
+        return $"Scene has {count} GameObjects";
+    }
+}
+```
+
+The return value is sent back as the command output. The script runs on Unity's main thread and has access to all Unity and UnityEditor APIs.
+
+### Custom skill documentation
+
+Add a `"skill": { "file": "SKILL.md" }` entry to plugin.json and create the markdown file. It will be included in the composed SKILL.md when running `unityctl skill rebuild`. Without it, documentation is auto-generated from the manifest.
+
+### Location
+
+| Level | Directory | Precedence |
+|-------|-----------|------------|
+| Project | `.unityctl/plugins/` | Higher |
+| User | `~/.unityctl/plugins/` | Lower |
+
+Use `--global` / `-g` with `plugin create` to scaffold at user level.
+
+## Executable Plugins
+
+Any executable named `unityctl-<name>` becomes available as `unityctl <name>`. Best for workflows outside Unity: build pipelines, CI scripts, multi-step orchestration.
+
+### How it works
+
+Place an executable (shell script, Python, Go binary, .bat/.cmd/.ps1 on Windows) named `unityctl-<name>` on PATH or in `.unityctl/plugins/`. All arguments after the command name are passed through.
+
+```bash
+unityctl smoke 30          # finds and runs unityctl-smoke with arg "30"
+unityctl deploy --staging  # finds and runs unityctl-deploy with arg "--staging"
+```
+
+### Environment variables
+
+The CLI sets these before launching the executable:
+
+| Variable | Description |
+|----------|-------------|
+| `UNITYCTL_PROJECT_PATH` | Resolved Unity project root |
+| `UNITYCTL_BRIDGE_PORT` | Bridge HTTP port |
+| `UNITYCTL_BRIDGE_URL` | Full bridge URL (e.g. `http://localhost:62908`) |
+| `UNITYCTL_AGENT_ID` | Agent ID if `--agent-id` was passed |
+| `UNITYCTL_JSON` | `"1"` if `--json` was passed |
+
+### Example
+
+```bash
+#!/usr/bin/env bash
+# Save as: unityctl-smoke (chmod +x)
+unityctl logs clear
+unityctl play enter
+sleep "${1:-10}"
+unityctl screenshot capture --json > /tmp/smoke.json
+ERRORS=$(unityctl logs -n 1000 --json | jq '[.entries[] | select(.level == "Error")] | length')
+unityctl play exit
+[ "$ERRORS" -eq 0 ] && echo "PASS" || { echo "FAIL: $ERRORS error(s)"; exit 1; }
+```
+
+### Companion skill file
+
+Place `unityctl-<name>.skill.md` next to the executable to provide custom documentation for SKILL.md composition. Without it, a minimal section is auto-generated.
+
+### Platform notes
+
+- **Windows**: matches `.exe`, `.cmd`, `.bat`, `.ps1` extensions
+- **Unix**: matches any file with execute permission; extensions are stripped from the command name (`unityctl-foo.sh` becomes `unityctl foo`)
+
+## Precedence
+
+built-in command > script plugin > executable plugin. A plugin cannot shadow a built-in command.
+
+## After changes
+
+Run `unityctl skill rebuild` to update the composed SKILL.md with plugin documentation.
+
+## Management commands
+
+```bash
+unityctl plugin list           # list all plugins (script + executable)
+unityctl plugin create <name>  # scaffold a script plugin
+unityctl plugin remove <name>  # remove a script plugin
+```

--- a/.claude/skills/unityctl-plugins/SKILL.md
+++ b/.claude/skills/unityctl-plugins/SKILL.md
@@ -83,13 +83,17 @@ Add a `"skill": { "file": "SKILL.md" }` entry to plugin.json and create the mark
 
 Use `--global` / `-g` with `plugin create` to scaffold at user level.
 
+Plugin names must be lowercase alphanumeric with hyphens (e.g. `my-tool`, `scene-stats`). Must start and end with a letter or digit.
+
 ## Executable Plugins
 
 Any executable named `unityctl-<name>` becomes available as `unityctl <name>`. Best for workflows outside Unity: build pipelines, CI scripts, multi-step orchestration.
 
 ### How it works
 
-Place an executable (shell script, Python, Go binary, .bat/.cmd/.ps1 on Windows) named `unityctl-<name>` on PATH or in `.unityctl/plugins/`. All arguments after the command name are passed through.
+Place an executable (shell script, Python, Go binary, .bat/.cmd/.ps1 on Windows) named `unityctl-<name>` in `.unityctl/plugins/` or on PATH. All arguments after the command name are passed through.
+
+Executables in plugin directories are registered at startup (appear in `--help`). Executables on PATH are resolved lazily when invoked — like `git` resolving `git foo` → `git-foo`.
 
 ```bash
 unityctl smoke 30          # finds and runs unityctl-smoke with arg "30"
@@ -142,7 +146,9 @@ Run `unityctl skill rebuild` to update the composed SKILL.md with plugin documen
 ## Management commands
 
 ```bash
-unityctl plugin list           # list all plugins (script + executable)
-unityctl plugin create <name>  # scaffold a script plugin
-unityctl plugin remove <name>  # remove a script plugin
+unityctl plugin list              # list all plugins (script + executable)
+unityctl plugin create <name>     # scaffold a script plugin
+unityctl plugin create <name> -g  # scaffold at user level (~/.unityctl/plugins/)
+unityctl plugin remove <name>     # remove a script plugin (prompts for confirmation)
+unityctl plugin remove <name> -f  # remove without confirmation
 ```

--- a/.claude/skills/unityctl-plugins/SKILL.md
+++ b/.claude/skills/unityctl-plugins/SKILL.md
@@ -149,6 +149,5 @@ Run `unityctl skill rebuild` to update the composed SKILL.md with plugin documen
 unityctl plugin list              # list all plugins (script + executable)
 unityctl plugin create <name>     # scaffold a script plugin
 unityctl plugin create <name> -g  # scaffold at user level (~/.unityctl/plugins/)
-unityctl plugin remove <name>     # remove a script plugin (prompts for confirmation)
-unityctl plugin remove <name> -f  # remove without confirmation
+unityctl plugin remove <name>     # remove a script plugin
 ```

--- a/.unityctl/plugins/sample-script/hello.cs
+++ b/.unityctl/plugins/sample-script/hello.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+public class Script
+{
+    public static object Main(string[] args)
+    {
+        var name = args.Length > 0 ? args[0] : "World";
+        var loud = System.Array.Exists(args, a => a == "--loud");
+        var greeting = $"Hello, {name}!";
+        if (loud) greeting = greeting.ToUpper();
+        Debug.Log(greeting);
+        return greeting;
+    }
+}

--- a/.unityctl/plugins/sample-script/plugin.json
+++ b/.unityctl/plugins/sample-script/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "sample-script",
+  "version": "1.0.0",
+  "description": "Sample script plugin demonstrating the plugin system",
+  "commands": [
+    {
+      "name": "hello",
+      "description": "Say hello from Unity",
+      "arguments": [
+        { "name": "name", "description": "Name to greet", "required": false }
+      ],
+      "options": [
+        { "name": "loud", "type": "bool", "description": "Shout the greeting" }
+      ],
+      "handler": { "type": "script", "file": "hello.cs" }
+    }
+  ]
+}

--- a/.unityctl/plugins/unityctl-sample-exec
+++ b/.unityctl/plugins/unityctl-sample-exec
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Sample executable plugin demonstrating the unityctl-{name} convention.
+# When discovered, this becomes: unityctl sample-exec [args...]
+#
+# Environment variables injected by unityctl:
+#   UNITYCTL_PROJECT_PATH  — Unity project root
+#   UNITYCTL_BRIDGE_PORT   — Bridge HTTP port
+#   UNITYCTL_BRIDGE_URL    — Bridge base URL
+#   UNITYCTL_AGENT_ID      — Agent identifier (if set)
+#   UNITYCTL_JSON          — "1" when --json flag is active
+
+if [ "$UNITYCTL_JSON" = "1" ]; then
+    echo "{\"message\":\"Hello from sample-exec plugin\",\"project\":\"${UNITYCTL_PROJECT_PATH}\"}"
+else
+    echo "Hello from sample-exec plugin!"
+    [ -n "$UNITYCTL_PROJECT_PATH" ] && echo "Project: $UNITYCTL_PROJECT_PATH"
+    [ -n "$UNITYCTL_BRIDGE_URL" ] && echo "Bridge: $UNITYCTL_BRIDGE_URL"
+fi

--- a/.unityctl/plugins/unityctl-sample-exec.skill.md
+++ b/.unityctl/plugins/unityctl-sample-exec.skill.md
@@ -1,0 +1,6 @@
+### Plugin: sample-exec (executable)
+
+A sample executable plugin that prints connection info. Demonstrates the `unityctl-{name}` naming convention.
+
+- `unityctl sample-exec [args...]`
+  Prints greeting and bridge connection details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,18 @@ dotnet test
 
 ## Skill
 
-Claude Code skill for AI integration: `.claude/skills/unity-editor/SKILL.md`
+The Claude Code skill has two layers:
+
+- **Base skill**: `UnityCtl.Cli/Resources/SKILL.md` — the source of truth, embedded into the CLI assembly. Edit this file when adding or changing CLI commands.
+- **Composed skill**: `.claude/skills/unity-editor/SKILL.md` — generated output (base + plugin docs + user extra). This is what Claude Code loads. Committed so it works on clone.
+
+After editing the base skill or changing plugins, regenerate the composed output:
+
+```bash
+./uc skill add --force    # or: ./uc skill rebuild
+```
+
+**Do not edit `.claude/skills/unity-editor/SKILL.md` directly** — it will be overwritten by the next rebuild.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,26 @@ This installs the Unity package and Claude Code skill. If run outside a Unity pr
 | `unityctl config set/get/list` | Manage configuration |
 | `unityctl package add/remove/status` | Manage Unity package |
 | `unityctl skill add/remove/status` | Manage Claude Code skill |
+| `unityctl skill rebuild` | Rebuild skill with plugin docs included |
+| `unityctl plugin list` | List discovered plugins |
+| `unityctl plugin create <name>` | Scaffold a new script plugin |
+| `unityctl plugin remove <name>` | Remove a script plugin |
 
 Run `unityctl --help` for the full command list.
+
+## Plugins
+
+Extend unityctl with custom commands — no changes to the bridge or Unity plugin required.
+
+- **Script plugins** — C# scripts executed inside Unity via the existing `script.execute` RPC. Best for commands that need Unity APIs.
+- **Executable plugins** — any `unityctl-<name>` binary on PATH or in `.unityctl/plugins/`, following the git/kubectl convention. Best for orchestration and CI workflows.
+
+```bash
+unityctl plugin create scene-stats   # scaffold a script plugin
+unityctl scene-stats stats           # use it like a built-in command
+```
+
+Plugins are discovered from `.unityctl/plugins/` (project-level) and `~/.unityctl/plugins/` (user-level). Their docs are automatically included in the Claude Code skill when you run `unityctl setup` or `unityctl skill rebuild`.
 
 ## Architecture
 
@@ -142,7 +160,8 @@ The API is kept simple, and leans mostly on the script execution to get work don
 - [ARCHITECTURE.md](ARCHITECTURE.md) - Technical details
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Development setup
 - [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Common issues
-- [.claude/skills/unity-editor/SKILL.md](.claude/skills/unity-editor/SKILL.md) - AI assistant skill file
+
+A Claude Code skill is installed as part of `unityctl setup` and kept up to date by `unityctl update`. It teaches Claude how to use the CLI without consuming context window on every task.
 
 ## License
 

--- a/UnityCtl.Cli/ContextHelper.cs
+++ b/UnityCtl.Cli/ContextHelper.cs
@@ -11,36 +11,24 @@ namespace UnityCtl.Cli;
 
 internal static class ContextHelper
 {
-    public static string? GetProjectPath(InvocationContext context)
-    {
-        var parseResult = context.ParseResult;
-        var rootCommand = parseResult.RootCommandResult.Command;
-        var option = rootCommand.Options.FirstOrDefault(o => o.Name == "project") as Option<string>;
-        return option != null ? parseResult.GetValueForOption(option) : null;
-    }
+    public static string? GetProjectPath(InvocationContext context) =>
+        GetGlobalOption<string>(context, "project");
 
-    public static string? GetAgentId(InvocationContext context)
-    {
-        var parseResult = context.ParseResult;
-        var rootCommand = parseResult.RootCommandResult.Command;
-        var option = rootCommand.Options.FirstOrDefault(o => o.Name == "agent-id") as Option<string>;
-        return option != null ? parseResult.GetValueForOption(option) : null;
-    }
+    public static string? GetAgentId(InvocationContext context) =>
+        GetGlobalOption<string>(context, "agent-id");
 
-    public static bool GetJson(InvocationContext context)
-    {
-        var parseResult = context.ParseResult;
-        var rootCommand = parseResult.RootCommandResult.Command;
-        var option = rootCommand.Options.FirstOrDefault(o => o.Name == "json") as Option<bool>;
-        return option != null && parseResult.GetValueForOption(option);
-    }
+    public static bool GetJson(InvocationContext context) =>
+        GetGlobalOption<bool>(context, "json");
 
-    public static int? GetTimeout(InvocationContext context)
+    public static int? GetTimeout(InvocationContext context) =>
+        GetGlobalOption<int?>(context, "timeout");
+
+    private static T? GetGlobalOption<T>(InvocationContext context, string name)
     {
         var parseResult = context.ParseResult;
-        var rootCommand = parseResult.RootCommandResult.Command;
-        var option = rootCommand.Options.FirstOrDefault(o => o.Name == "timeout") as Option<int?>;
-        return option != null ? parseResult.GetValueForOption(option) : null;
+        var option = parseResult.RootCommandResult.Command.Options
+            .FirstOrDefault(o => o.Name == name) as Option<T>;
+        return option != null ? parseResult.GetValueForOption(option) : default;
     }
 
     public static bool? GetResultBool(ResponseMessage response, string key)

--- a/UnityCtl.Cli/ExecutablePluginLoader.cs
+++ b/UnityCtl.Cli/ExecutablePluginLoader.cs
@@ -18,7 +18,7 @@ namespace UnityCtl.Cli;
 public static class ExecutablePluginLoader
 {
     private const string ExecutablePrefix = "unityctl-";
-    private static readonly string[] WindowsExecutableExtensions = [".exe", ".cmd", ".bat", ".ps1"];
+    private static readonly string[] CompanionExtensions = [".skill.md"];
 
     /// <summary>
     /// Discovers all executable plugins from plugin directories and optionally PATH.
@@ -61,128 +61,34 @@ public static class ExecutablePluginLoader
     /// lookup during process start, so no upfront scanning is needed.
     /// Returns null if no such executable exists, or the exit code if it ran.
     /// </summary>
-    public static async Task<int?> TryExecuteByName(string name, string[] passThrough)
+    public static async Task<int?> TryExecuteByName(
+        string name, string[] passThrough,
+        string? projectPath = null, string? agentId = null, bool json = false)
     {
         var executableName = $"{ExecutablePrefix}{name}";
 
-        // Inject environment variables (best-effort, no InvocationContext available)
-        var envVars = new Dictionary<string, string>();
-        var projectRoot = ProjectLocator.FindProjectRoot();
-        if (projectRoot != null)
-        {
-            envVars["UNITYCTL_PROJECT_PATH"] = projectRoot;
-            var bridgeConfig = ProjectLocator.ReadBridgeConfig(projectRoot);
-            if (bridgeConfig != null)
-            {
-                envVars["UNITYCTL_BRIDGE_PORT"] = bridgeConfig.Port.ToString();
-                envVars["UNITYCTL_BRIDGE_URL"] = $"http://localhost:{bridgeConfig.Port}";
-            }
-        }
+        var startInfo = CreateStartInfo(executableName, passThrough);
+        SetPluginEnvironment(startInfo, projectPath, agentId, json);
 
         // Try to start "unityctl-<name>" directly. On Unix the OS resolves PATH.
         // On Windows with UseShellExecute=false, this finds .exe files on PATH.
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = executableName,
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
-
-        foreach (var token in passThrough)
-            startInfo.ArgumentList.Add(token);
-
-        foreach (var (key, value) in envVars)
-            startInfo.Environment[key] = value;
-
-        try
-        {
-            using var process = Process.Start(startInfo);
-            if (process == null)
-                return null;
-
-            var stdoutTask = StreamOutputAsync(process.StandardOutput, Console.Out);
-            var stderrTask = StreamOutputAsync(process.StandardError, Console.Error);
-
-            await Task.WhenAll(stdoutTask, stderrTask);
-            await process.WaitForExitAsync();
-
-            return process.ExitCode;
-        }
-        catch (System.ComponentModel.Win32Exception)
-        {
-            // Not found as a direct executable
-        }
+        var result = await RunAndStreamAsync(startInfo);
+        if (result.HasValue)
+            return result.Value;
 
         // On Windows, .bat/.cmd scripts need cmd.exe /c to run.
         // Use PATHEXT-aware lookup via "where" to find the exact path first,
         // so we don't blindly invoke cmd.exe for non-existent commands.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            string? resolvedPath = null;
-            try
-            {
-                var whereInfo = new ProcessStartInfo
-                {
-                    FileName = "where.exe",
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true
-                };
-                whereInfo.ArgumentList.Add(executableName);
-
-                using var whereProc = Process.Start(whereInfo);
-                if (whereProc != null)
-                {
-                    resolvedPath = (await whereProc.StandardOutput.ReadLineAsync())?.Trim();
-                    await whereProc.WaitForExitAsync();
-                    if (whereProc.ExitCode != 0)
-                        resolvedPath = null;
-                }
-            }
-            catch
-            {
-                // where.exe not available — give up
-            }
-
+            var resolvedPath = await ResolveViaWhere(executableName);
             if (resolvedPath != null)
             {
-                var cmdInfo = new ProcessStartInfo
-                {
-                    FileName = "cmd.exe",
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true
-                };
-                cmdInfo.ArgumentList.Add("/c");
-                cmdInfo.ArgumentList.Add(resolvedPath);
-
-                foreach (var token in passThrough)
-                    cmdInfo.ArgumentList.Add(token);
-
-                foreach (var (key, value) in envVars)
-                    cmdInfo.Environment[key] = value;
-
-                try
-                {
-                    using var process = Process.Start(cmdInfo);
-                    if (process != null)
-                    {
-                        var stdoutTask = StreamOutputAsync(process.StandardOutput, Console.Out);
-                        var stderrTask = StreamOutputAsync(process.StandardError, Console.Error);
-
-                        await Task.WhenAll(stdoutTask, stderrTask);
-                        await process.WaitForExitAsync();
-                        return process.ExitCode;
-                    }
-                }
-                catch (System.ComponentModel.Win32Exception)
-                {
-                    // Resolved path but still couldn't execute
-                }
+                var cmdInfo = CreateStartInfo("cmd.exe", ["/c", resolvedPath, .. passThrough]);
+                SetPluginEnvironment(cmdInfo, projectPath, agentId, json);
+                result = await RunAndStreamAsync(cmdInfo);
+                if (result.HasValue)
+                    return result.Value;
             }
         }
 
@@ -249,39 +155,37 @@ public static class ExecutablePluginLoader
         ExecutablePlugin plugin,
         IReadOnlyList<string> passThrough)
     {
-        var projectPath = ContextHelper.GetProjectPath(context);
-        var agentId = ContextHelper.GetAgentId(context);
-        var json = ContextHelper.GetJson(context);
+        var startInfo = CreateStartInfo(plugin.Path, passThrough);
+        SetPluginEnvironment(startInfo,
+            ContextHelper.GetProjectPath(context),
+            ContextHelper.GetAgentId(context),
+            ContextHelper.GetJson(context));
 
-        // Resolve project root and bridge config for environment variables
+        var result = await RunAndStreamAsync(startInfo);
+        if (result.HasValue)
+            return result.Value;
+
+        Console.Error.WriteLine($"Error: Failed to start plugin executable: {plugin.Path}");
+        return 1;
+    }
+
+    /// <summary>
+    /// Sets bridge connection and global option environment variables on a ProcessStartInfo.
+    /// </summary>
+    private static void SetPluginEnvironment(
+        ProcessStartInfo startInfo,
+        string? projectPath = null, string? agentId = null, bool json = false)
+    {
         var projectRoot = projectPath ?? ProjectLocator.FindProjectRoot();
-        BridgeConfig? bridgeConfig = null;
         if (projectRoot != null)
         {
-            bridgeConfig = ProjectLocator.ReadBridgeConfig(projectRoot);
-        }
-
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = plugin.Path,
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
-
-        // Pass through all arguments
-        foreach (var token in passThrough)
-            startInfo.ArgumentList.Add(token);
-
-        // Set environment variables for plugin discovery
-        if (projectRoot != null)
             startInfo.Environment["UNITYCTL_PROJECT_PATH"] = projectRoot;
-
-        if (bridgeConfig != null)
-        {
-            startInfo.Environment["UNITYCTL_BRIDGE_PORT"] = bridgeConfig.Port.ToString();
-            startInfo.Environment["UNITYCTL_BRIDGE_URL"] = $"http://localhost:{bridgeConfig.Port}";
+            var bridgeConfig = ProjectLocator.ReadBridgeConfig(projectRoot);
+            if (bridgeConfig != null)
+            {
+                startInfo.Environment["UNITYCTL_BRIDGE_PORT"] = bridgeConfig.Port.ToString();
+                startInfo.Environment["UNITYCTL_BRIDGE_URL"] = $"http://localhost:{bridgeConfig.Port}";
+            }
         }
 
         if (agentId != null)
@@ -289,39 +193,70 @@ public static class ExecutablePluginLoader
 
         if (json)
             startInfo.Environment["UNITYCTL_JSON"] = "1";
+    }
 
+    private static ProcessStartInfo CreateStartInfo(string fileName, IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var token in arguments)
+            startInfo.ArgumentList.Add(token);
+
+        return startInfo;
+    }
+
+    /// <summary>
+    /// Starts a process, streams its stdout/stderr to the console, and returns the exit code.
+    /// Returns null if the process could not be started (e.g., executable not found).
+    /// </summary>
+    private static async Task<int?> RunAndStreamAsync(ProcessStartInfo startInfo)
+    {
         try
         {
             using var process = Process.Start(startInfo);
             if (process == null)
-            {
-                Console.Error.WriteLine($"Error: Failed to start plugin executable: {plugin.Path}");
-                return 1;
-            }
+                return null;
 
-            // Stream stdout and stderr concurrently
-            var stdoutTask = StreamOutputAsync(process.StandardOutput, Console.Out);
-            var stderrTask = StreamOutputAsync(process.StandardError, Console.Error);
+            var stdoutTask = process.StandardOutput.BaseStream.CopyToAsync(Console.OpenStandardOutput());
+            var stderrTask = process.StandardError.BaseStream.CopyToAsync(Console.OpenStandardError());
 
             await Task.WhenAll(stdoutTask, stderrTask);
             await process.WaitForExitAsync();
 
             return process.ExitCode;
         }
-        catch (Exception ex)
+        catch (System.ComponentModel.Win32Exception)
         {
-            Console.Error.WriteLine($"Error: Failed to execute plugin '{plugin.Name}': {ex.Message}");
-            return 1;
+            return null;
         }
     }
 
-    private static async Task StreamOutputAsync(StreamReader reader, TextWriter writer)
+    /// <summary>
+    /// Uses "where.exe" to resolve an executable name via PATHEXT on Windows.
+    /// </summary>
+    private static async Task<string?> ResolveViaWhere(string executableName)
     {
-        var buffer = new char[4096];
-        int read;
-        while ((read = await reader.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        try
         {
-            await writer.WriteAsync(buffer, 0, read);
+            var whereInfo = CreateStartInfo("where.exe", [executableName]);
+            using var whereProc = Process.Start(whereInfo);
+            if (whereProc == null)
+                return null;
+
+            var resolvedPath = (await whereProc.StandardOutput.ReadLineAsync())?.Trim();
+            await whereProc.WaitForExitAsync();
+            return whereProc.ExitCode == 0 ? resolvedPath : null;
+        }
+        catch
+        {
+            return null;
         }
     }
 
@@ -373,7 +308,6 @@ public static class ExecutablePluginLoader
         IEnumerable<string> files;
         try
         {
-            // Use wildcard to filter at OS level instead of enumerating all files
             files = Directory.EnumerateFiles(directory, "unityctl-*");
         }
         catch
@@ -383,50 +317,34 @@ public static class ExecutablePluginLoader
 
         foreach (var filePath in files)
         {
-            var fileName = Path.GetFileNameWithoutExtension(filePath);
-            var extension = Path.GetExtension(filePath).ToLowerInvariant();
+            var fullFileName = Path.GetFileName(filePath);
 
-            if (!fileName.StartsWith(ExecutablePrefix, StringComparison.OrdinalIgnoreCase))
+            if (!fullFileName.StartsWith(ExecutablePrefix, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // Skip companion files (e.g., unityctl-foo.skill.md)
+            if (CompanionExtensions.Any(ext => fullFileName.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            // On Unix, require execute permission
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !IsUnixExecutable(filePath))
+                continue;
+
+            // Extract command name: strip prefix, then strip extension
+            var name = fullFileName.Substring(ExecutablePrefix.Length);
+            var dotIndex = name.IndexOf('.');
+            if (dotIndex > 0)
+                name = name.Substring(0, dotIndex);
+
+            if (string.IsNullOrEmpty(name))
+                continue;
+
+            yield return new ExecutablePlugin
             {
-                if (!WindowsExecutableExtensions.Contains(extension))
-                    continue;
-
-                var name = fileName.Substring(ExecutablePrefix.Length);
-                if (string.IsNullOrEmpty(name))
-                    continue;
-
-                yield return new ExecutablePlugin
-                {
-                    Name = name.ToLowerInvariant(),
-                    Path = filePath,
-                    Source = source
-                };
-            }
-            else
-            {
-                if (!IsUnixExecutable(filePath))
-                    continue;
-
-                var fullFileName = Path.GetFileName(filePath);
-                var name = fullFileName.Substring(ExecutablePrefix.Length);
-                // Strip extension if present (e.g., unityctl-foo.sh → foo)
-                var dotIndex = name.IndexOf('.');
-                if (dotIndex > 0)
-                    name = name.Substring(0, dotIndex);
-
-                if (string.IsNullOrEmpty(name))
-                    continue;
-
-                yield return new ExecutablePlugin
-                {
-                    Name = name.ToLowerInvariant(),
-                    Path = filePath,
-                    Source = source
-                };
-            }
+                Name = name.ToLowerInvariant(),
+                Path = filePath,
+                Source = source
+            };
         }
     }
 

--- a/UnityCtl.Cli/ExecutablePluginLoader.cs
+++ b/UnityCtl.Cli/ExecutablePluginLoader.cs
@@ -255,6 +255,8 @@ public static class ExecutablePluginLoader
                 return null;
 
             var resolvedPath = (await whereProc.StandardOutput.ReadLineAsync())?.Trim();
+            // Drain stderr to prevent potential deadlock if where.exe writes to it
+            await whereProc.StandardError.ReadToEndAsync();
             await whereProc.WaitForExitAsync();
             return whereProc.ExitCode == 0 ? resolvedPath : null;
         }
@@ -307,7 +309,7 @@ public static class ExecutablePluginLoader
         }
     }
 
-    private static IEnumerable<ExecutablePlugin> ScanDirectoryForExecutables(string directory, string source)
+    internal static IEnumerable<ExecutablePlugin> ScanDirectoryForExecutables(string directory, string source)
     {
         IEnumerable<string> files;
         try
@@ -337,7 +339,7 @@ public static class ExecutablePluginLoader
             // Extract command name: strip prefix, then strip extension
             var name = fullFileName.Substring(ExecutablePrefix.Length);
             var dotIndex = name.IndexOf('.');
-            if (dotIndex > 0)
+            if (dotIndex >= 0)
                 name = name.Substring(0, dotIndex);
 
             if (string.IsNullOrEmpty(name))

--- a/UnityCtl.Cli/ExecutablePluginLoader.cs
+++ b/UnityCtl.Cli/ExecutablePluginLoader.cs
@@ -21,19 +21,27 @@ public static class ExecutablePluginLoader
     private static readonly string[] WindowsExecutableExtensions = [".exe", ".cmd", ".bat", ".ps1"];
 
     /// <summary>
-    /// Discovers all executable plugins from PATH and plugin directories.
-    /// Returns deduplicated list; plugin directories take precedence over PATH.
+    /// Discovers all executable plugins from plugin directories and optionally PATH.
+    /// Plugin directories take precedence over PATH.
     /// </summary>
-    public static List<ExecutablePlugin> DiscoverExecutablePlugins(ISet<string>? excludeNames = null)
+    /// <param name="excludeNames">Command names to skip (built-in + script plugins).</param>
+    /// <param name="includePath">
+    /// When true, also scans PATH directories (expensive). Only used by `plugin list`.
+    /// At startup, PATH executables are resolved lazily via <see cref="TryExecuteByName"/>.
+    /// </param>
+    public static List<ExecutablePlugin> DiscoverExecutablePlugins(ISet<string>? excludeNames = null, bool includePath = false)
     {
         var plugins = new Dictionary<string, ExecutablePlugin>(StringComparer.OrdinalIgnoreCase);
 
-        // PATH first (lower precedence)
-        foreach (var plugin in ScanPath())
+        // PATH first (lower precedence) — only when explicitly requested
+        if (includePath)
         {
-            if (excludeNames != null && excludeNames.Contains(plugin.Name))
-                continue;
-            plugins[plugin.Name] = plugin;
+            foreach (var plugin in ScanPath())
+            {
+                if (excludeNames != null && excludeNames.Contains(plugin.Name))
+                    continue;
+                plugins[plugin.Name] = plugin;
+            }
         }
 
         // Plugin directories second (higher precedence, overwrites PATH)
@@ -45,6 +53,62 @@ public static class ExecutablePluginLoader
         }
 
         return plugins.Values.ToList();
+    }
+
+    /// <summary>
+    /// Attempts to execute an unrecognized command as "unityctl-{name}" on PATH,
+    /// similar to how git resolves "git foo" → "git-foo". The OS performs the PATH
+    /// lookup during process start, so no upfront scanning is needed.
+    /// Returns null if no such executable exists, or the exit code if it ran.
+    /// </summary>
+    public static async Task<int?> TryExecuteByName(string name, string[] passThrough)
+    {
+        var executableName = $"{ExecutablePrefix}{name}";
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executableName,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var token in passThrough)
+            startInfo.ArgumentList.Add(token);
+
+        // Inject environment variables (best-effort, no InvocationContext available)
+        var projectRoot = ProjectLocator.FindProjectRoot();
+        if (projectRoot != null)
+        {
+            startInfo.Environment["UNITYCTL_PROJECT_PATH"] = projectRoot;
+            var bridgeConfig = ProjectLocator.ReadBridgeConfig(projectRoot);
+            if (bridgeConfig != null)
+            {
+                startInfo.Environment["UNITYCTL_BRIDGE_PORT"] = bridgeConfig.Port.ToString();
+                startInfo.Environment["UNITYCTL_BRIDGE_URL"] = $"http://localhost:{bridgeConfig.Port}";
+            }
+        }
+
+        try
+        {
+            using var process = Process.Start(startInfo);
+            if (process == null)
+                return null;
+
+            var stdoutTask = StreamOutputAsync(process.StandardOutput, Console.Out);
+            var stderrTask = StreamOutputAsync(process.StandardError, Console.Error);
+
+            await Task.WhenAll(stdoutTask, stderrTask);
+            await process.WaitForExitAsync();
+
+            return process.ExitCode;
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // Executable not found on PATH
+            return null;
+        }
     }
 
     /// <summary>
@@ -299,8 +363,7 @@ public static class ExecutablePluginLoader
         }
         catch
         {
-            // Fallback: assume executable if on Unix and we can't determine
-            return true;
+            return false;
         }
     }
 }

--- a/UnityCtl.Cli/ExecutablePluginLoader.cs
+++ b/UnityCtl.Cli/ExecutablePluginLoader.cs
@@ -292,20 +292,13 @@ public static class ExecutablePluginLoader
 
     private static IEnumerable<ExecutablePlugin> ScanPluginDirectories()
     {
-        // User-level: ~/.unityctl/plugins/
-        var userDir = PluginLoader.GetUserPluginsDirectory();
-        if (Directory.Exists(userDir))
+        foreach (var (dir, source) in PluginLoader.GetPluginDirectories())
         {
-            foreach (var plugin in ScanDirectoryForExecutables(userDir, "user"))
-                yield return plugin;
-        }
-
-        // Project-level: .unityctl/plugins/
-        var projectDir = PluginLoader.GetProjectPluginsDirectory();
-        if (projectDir != null && Directory.Exists(projectDir))
-        {
-            foreach (var plugin in ScanDirectoryForExecutables(projectDir, "project"))
-                yield return plugin;
+            if (Directory.Exists(dir))
+            {
+                foreach (var plugin in ScanDirectoryForExecutables(dir, source))
+                    yield return plugin;
+            }
         }
     }
 

--- a/UnityCtl.Cli/ExecutablePluginLoader.cs
+++ b/UnityCtl.Cli/ExecutablePluginLoader.cs
@@ -76,14 +76,20 @@ public static class ExecutablePluginLoader
         if (result.HasValue)
             return result.Value;
 
-        // On Windows, .bat/.cmd scripts need cmd.exe /c to run.
-        // Use PATHEXT-aware lookup via "where" to find the exact path first,
-        // so we don't blindly invoke cmd.exe for non-existent commands.
+        // On Windows, extensionless scripts and .bat/.cmd files can't be started directly.
+        // Resolve the actual file via "where", then route through the appropriate interpreter.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             var resolvedPath = await ResolveViaWhere(executableName);
             if (resolvedPath != null)
             {
+                var resolvedInfo = CreateStartInfoForPlugin(resolvedPath, passThrough);
+                SetPluginEnvironment(resolvedInfo, projectPath, agentId, json, timeout);
+                result = await RunAndStreamAsync(resolvedInfo);
+                if (result.HasValue)
+                    return result.Value;
+
+                // Fall back to cmd.exe /c for .bat/.cmd files
                 var cmdInfo = CreateStartInfo("cmd.exe", ["/c", resolvedPath, .. passThrough]);
                 SetPluginEnvironment(cmdInfo, projectPath, agentId, json, timeout);
                 result = await RunAndStreamAsync(cmdInfo);
@@ -155,7 +161,7 @@ public static class ExecutablePluginLoader
         ExecutablePlugin plugin,
         IReadOnlyList<string> passThrough)
     {
-        var startInfo = CreateStartInfo(plugin.Path, passThrough);
+        var startInfo = CreateStartInfoForPlugin(plugin.Path, passThrough);
         SetPluginEnvironment(startInfo,
             ContextHelper.GetProjectPath(context),
             ContextHelper.GetAgentId(context),
@@ -168,6 +174,92 @@ public static class ExecutablePluginLoader
 
         Console.Error.WriteLine($"Error: Failed to start plugin executable: {plugin.Path}");
         return 1;
+    }
+
+    /// <summary>
+    /// Creates a ProcessStartInfo for a discovered plugin file. On Windows, extensionless
+    /// scripts with a shebang line (e.g. #!/usr/bin/env bash) are routed through the
+    /// interpreter since Windows can't handle shebangs natively.
+    /// </summary>
+    private static ProcessStartInfo CreateStartInfoForPlugin(string filePath, IReadOnlyList<string> arguments)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Path.HasExtension(filePath))
+        {
+            var interpreter = ReadShebangInterpreter(filePath);
+            if (interpreter != null)
+            {
+                // On Windows, "bash" might resolve to WSL's bash.exe which can't see
+                // Windows paths. Use Git Bash instead when available.
+                var resolvedInterpreter = ResolveWindowsInterpreter(interpreter);
+                return CreateStartInfo(resolvedInterpreter, [filePath, .. arguments]);
+            }
+        }
+
+        return CreateStartInfo(filePath, arguments);
+    }
+
+    /// <summary>
+    /// Resolves an interpreter name to a full path on Windows, preferring Git Bash
+    /// over WSL's bash.exe which runs in a separate Linux environment.
+    /// </summary>
+    private static string ResolveWindowsInterpreter(string interpreter)
+    {
+        if (interpreter is "bash" or "sh")
+        {
+            // Try Git for Windows first (most common on developer machines)
+            var gitBash = FindGitBash();
+            if (gitBash != null)
+                return gitBash;
+        }
+
+        return interpreter;
+    }
+
+    private static string? FindGitBash()
+    {
+        // Standard Git for Windows install locations
+        var candidates = new[]
+        {
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Git", "usr", "bin", "bash.exe"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Git", "usr", "bin", "bash.exe"),
+        };
+
+        foreach (var path in candidates)
+        {
+            if (File.Exists(path))
+                return path;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reads the first line of a file and extracts the interpreter from a shebang line.
+    /// Handles "#!/usr/bin/env bash" → "bash" and "#!/bin/bash" → "bash".
+    /// Returns null if no shebang is found.
+    /// </summary>
+    internal static string? ReadShebangInterpreter(string filePath)
+    {
+        try
+        {
+            using var reader = new StreamReader(filePath);
+            var firstLine = reader.ReadLine();
+            if (firstLine == null || !firstLine.StartsWith("#!"))
+                return null;
+
+            var shebang = firstLine.Substring(2).Trim();
+
+            // "#!/usr/bin/env bash" → "bash"
+            if (shebang.StartsWith("/usr/bin/env "))
+                return shebang.Substring("/usr/bin/env ".Length).Trim();
+
+            // "#!/bin/bash" → "bash"
+            return Path.GetFileName(shebang);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/UnityCtl.Cli/ExecutablePluginLoader.cs
+++ b/UnityCtl.Cli/ExecutablePluginLoader.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using UnityCtl.Protocol;
+
+namespace UnityCtl.Cli;
+
+/// <summary>
+/// Discovers executables named "unityctl-{name}" on PATH and in plugin directories,
+/// and registers them as top-level CLI commands (git/kubectl convention).
+/// </summary>
+public static class ExecutablePluginLoader
+{
+    private const string ExecutablePrefix = "unityctl-";
+
+    /// <summary>
+    /// Discovers all executable plugins from PATH and plugin directories.
+    /// Returns deduplicated list; plugin directories take precedence over PATH.
+    /// </summary>
+    public static List<ExecutablePlugin> DiscoverExecutablePlugins(ISet<string>? excludeNames = null)
+    {
+        var plugins = new Dictionary<string, ExecutablePlugin>(StringComparer.OrdinalIgnoreCase);
+
+        // PATH first (lower precedence)
+        foreach (var plugin in ScanPath())
+        {
+            if (excludeNames != null && excludeNames.Contains(plugin.Name))
+                continue;
+            plugins[plugin.Name] = plugin;
+        }
+
+        // Plugin directories second (higher precedence, overwrites PATH)
+        foreach (var plugin in ScanPluginDirectories())
+        {
+            if (excludeNames != null && excludeNames.Contains(plugin.Name))
+                continue;
+            plugins[plugin.Name] = plugin;
+        }
+
+        return plugins.Values.ToList();
+    }
+
+    /// <summary>
+    /// Creates a System.CommandLine command for an executable plugin.
+    /// All unrecognized tokens are passed through as arguments to the executable.
+    /// </summary>
+    public static Command CreateCommandFromExecutablePlugin(ExecutablePlugin plugin)
+    {
+        var command = new Command(plugin.Name, plugin.Description ?? $"Executable plugin: {plugin.Name}");
+
+        // Catch-all argument to pass everything through to the executable
+        var argsArgument = new Argument<string[]>("args")
+        {
+            Description = "Arguments to pass to the plugin executable",
+            Arity = ArgumentArity.ZeroOrMore
+        };
+        command.AddArgument(argsArgument);
+
+        command.SetHandler(async (InvocationContext context) =>
+        {
+            var passThrough = context.ParseResult.GetValueForArgument(argsArgument);
+            context.ExitCode = await ExecutePluginAsync(context, plugin, passThrough);
+        });
+
+        return command;
+    }
+
+    /// <summary>
+    /// Generates a SKILL.md section for an executable plugin from its companion .skill.md file.
+    /// Returns null if no companion file exists.
+    /// </summary>
+    public static string? GetSkillSection(ExecutablePlugin plugin)
+    {
+        // Look for companion skill file: unityctl-foo.skill.md next to the executable
+        var dir = Path.GetDirectoryName(plugin.Path);
+        if (dir == null) return null;
+
+        var skillFileName = $"{ExecutablePrefix}{plugin.Name}.skill.md";
+        var skillPath = Path.Combine(dir, skillFileName);
+        if (File.Exists(skillPath))
+            return File.ReadAllText(skillPath);
+
+        // Auto-generate minimal section
+        var lines = new List<string>
+        {
+            $"### Plugin: {plugin.Name} (executable)",
+        };
+        if (!string.IsNullOrEmpty(plugin.Description))
+            lines.Add($"\n{plugin.Description}");
+        lines.Add("");
+        lines.Add($"- `unityctl {plugin.Name} [args...]`");
+        lines.Add($"  Runs external executable: {Path.GetFileName(plugin.Path)}");
+        lines.Add("");
+
+        return string.Join("\n", lines);
+    }
+
+    private static async Task<int> ExecutePluginAsync(
+        InvocationContext context,
+        ExecutablePlugin plugin,
+        IReadOnlyList<string> passThrough)
+    {
+        var projectPath = ContextHelper.GetProjectPath(context);
+        var agentId = ContextHelper.GetAgentId(context);
+        var json = ContextHelper.GetJson(context);
+
+        // Resolve project root and bridge config for environment variables
+        var projectRoot = projectPath ?? ProjectLocator.FindProjectRoot();
+        BridgeConfig? bridgeConfig = null;
+        if (projectRoot != null)
+        {
+            bridgeConfig = ProjectLocator.ReadBridgeConfig(projectRoot);
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = plugin.Path,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        // Pass through all arguments
+        foreach (var token in passThrough)
+            startInfo.ArgumentList.Add(token);
+
+        // Set environment variables for plugin discovery
+        if (projectRoot != null)
+            startInfo.Environment["UNITYCTL_PROJECT_PATH"] = projectRoot;
+
+        if (bridgeConfig != null)
+        {
+            startInfo.Environment["UNITYCTL_BRIDGE_PORT"] = bridgeConfig.Port.ToString();
+            startInfo.Environment["UNITYCTL_BRIDGE_URL"] = $"http://localhost:{bridgeConfig.Port}";
+        }
+
+        if (agentId != null)
+            startInfo.Environment["UNITYCTL_AGENT_ID"] = agentId;
+
+        if (json)
+            startInfo.Environment["UNITYCTL_JSON"] = "1";
+
+        try
+        {
+            using var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                Console.Error.WriteLine($"Error: Failed to start plugin executable: {plugin.Path}");
+                return 1;
+            }
+
+            // Stream stdout and stderr concurrently
+            var stdoutTask = StreamOutputAsync(process.StandardOutput, Console.Out);
+            var stderrTask = StreamOutputAsync(process.StandardError, Console.Error);
+
+            await Task.WhenAll(stdoutTask, stderrTask);
+            await process.WaitForExitAsync();
+
+            return process.ExitCode;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: Failed to execute plugin '{plugin.Name}': {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static async Task StreamOutputAsync(StreamReader reader, TextWriter writer)
+    {
+        var buffer = new char[4096];
+        int read;
+        while ((read = await reader.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        {
+            await writer.WriteAsync(buffer, 0, read);
+        }
+    }
+
+    private static IEnumerable<ExecutablePlugin> ScanPath()
+    {
+        var pathVar = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathVar))
+            yield break;
+
+        var separator = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ';' : ':';
+        var dirs = pathVar.Split(separator, StringSplitOptions.RemoveEmptyEntries);
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var dir in dirs)
+        {
+            if (!Directory.Exists(dir))
+                continue;
+
+            foreach (var plugin in ScanDirectoryForExecutables(dir, "path"))
+            {
+                if (seen.Add(plugin.Name))
+                    yield return plugin;
+            }
+        }
+    }
+
+    private static IEnumerable<ExecutablePlugin> ScanPluginDirectories()
+    {
+        // User-level: ~/.unityctl/plugins/
+        var userDir = PluginLoader.GetUserPluginsDirectory();
+        if (Directory.Exists(userDir))
+        {
+            foreach (var plugin in ScanDirectoryForExecutables(userDir, "user"))
+                yield return plugin;
+        }
+
+        // Project-level: .unityctl/plugins/
+        var projectDir = PluginLoader.GetProjectPluginsDirectory();
+        if (projectDir != null && Directory.Exists(projectDir))
+        {
+            foreach (var plugin in ScanDirectoryForExecutables(projectDir, "project"))
+                yield return plugin;
+        }
+    }
+
+    private static IEnumerable<ExecutablePlugin> ScanDirectoryForExecutables(string directory, string source)
+    {
+        IEnumerable<string> files;
+        try
+        {
+            files = Directory.EnumerateFiles(directory);
+        }
+        catch
+        {
+            yield break;
+        }
+
+        foreach (var filePath in files)
+        {
+            var fileName = Path.GetFileNameWithoutExtension(filePath);
+            var extension = Path.GetExtension(filePath).ToLowerInvariant();
+
+            // On Windows, also match files with executable extensions
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Match: unityctl-foo.exe, unityctl-foo.cmd, unityctl-foo.bat, unityctl-foo.ps1
+                var executableExtensions = new[] { ".exe", ".cmd", ".bat", ".ps1" };
+
+                if (!fileName.StartsWith(ExecutablePrefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!executableExtensions.Contains(extension))
+                    continue;
+
+                var name = fileName.Substring(ExecutablePrefix.Length);
+                if (string.IsNullOrEmpty(name))
+                    continue;
+
+                yield return new ExecutablePlugin
+                {
+                    Name = name.ToLowerInvariant(),
+                    Path = filePath,
+                    Source = source
+                };
+            }
+            else
+            {
+                // On Unix: match any executable file named unityctl-*
+                var fullFileName = Path.GetFileName(filePath);
+                if (!fullFileName.StartsWith(ExecutablePrefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // Check if file is executable (has any execute bit)
+                if (!IsUnixExecutable(filePath))
+                    continue;
+
+                var name = fullFileName.Substring(ExecutablePrefix.Length);
+                // Strip extension if present (e.g., unityctl-foo.sh → foo)
+                var dotIndex = name.IndexOf('.');
+                if (dotIndex > 0)
+                    name = name.Substring(0, dotIndex);
+
+                if (string.IsNullOrEmpty(name))
+                    continue;
+
+                yield return new ExecutablePlugin
+                {
+                    Name = name.ToLowerInvariant(),
+                    Path = filePath,
+                    Source = source
+                };
+            }
+        }
+    }
+
+    private static bool IsUnixExecutable(string filePath)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return false;
+
+        try
+        {
+            return (File.GetUnixFileMode(filePath) & (UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute)) != 0;
+        }
+        catch
+        {
+            // Fallback: assume executable if on Unix and we can't determine
+            return true;
+        }
+    }
+}
+
+public class ExecutablePlugin
+{
+    public required string Name { get; set; }
+    public required string Path { get; set; }
+    public required string Source { get; set; }
+    public string? Description { get; set; }
+}

--- a/UnityCtl.Cli/ExecutablePluginLoader.cs
+++ b/UnityCtl.Cli/ExecutablePluginLoader.cs
@@ -63,12 +63,12 @@ public static class ExecutablePluginLoader
     /// </summary>
     public static async Task<int?> TryExecuteByName(
         string name, string[] passThrough,
-        string? projectPath = null, string? agentId = null, bool json = false)
+        string? projectPath = null, string? agentId = null, bool json = false, int? timeout = null)
     {
         var executableName = $"{ExecutablePrefix}{name}";
 
         var startInfo = CreateStartInfo(executableName, passThrough);
-        SetPluginEnvironment(startInfo, projectPath, agentId, json);
+        SetPluginEnvironment(startInfo, projectPath, agentId, json, timeout);
 
         // Try to start "unityctl-<name>" directly. On Unix the OS resolves PATH.
         // On Windows with UseShellExecute=false, this finds .exe files on PATH.
@@ -85,7 +85,7 @@ public static class ExecutablePluginLoader
             if (resolvedPath != null)
             {
                 var cmdInfo = CreateStartInfo("cmd.exe", ["/c", resolvedPath, .. passThrough]);
-                SetPluginEnvironment(cmdInfo, projectPath, agentId, json);
+                SetPluginEnvironment(cmdInfo, projectPath, agentId, json, timeout);
                 result = await RunAndStreamAsync(cmdInfo);
                 if (result.HasValue)
                     return result.Value;
@@ -159,7 +159,8 @@ public static class ExecutablePluginLoader
         SetPluginEnvironment(startInfo,
             ContextHelper.GetProjectPath(context),
             ContextHelper.GetAgentId(context),
-            ContextHelper.GetJson(context));
+            ContextHelper.GetJson(context),
+            ContextHelper.GetTimeout(context));
 
         var result = await RunAndStreamAsync(startInfo);
         if (result.HasValue)
@@ -174,7 +175,7 @@ public static class ExecutablePluginLoader
     /// </summary>
     private static void SetPluginEnvironment(
         ProcessStartInfo startInfo,
-        string? projectPath = null, string? agentId = null, bool json = false)
+        string? projectPath = null, string? agentId = null, bool json = false, int? timeout = null)
     {
         var projectRoot = projectPath ?? ProjectLocator.FindProjectRoot();
         if (projectRoot != null)
@@ -193,6 +194,9 @@ public static class ExecutablePluginLoader
 
         if (json)
             startInfo.Environment["UNITYCTL_JSON"] = "1";
+
+        if (timeout.HasValue)
+            startInfo.Environment["UNITYCTL_TIMEOUT"] = timeout.Value.ToString();
     }
 
     private static ProcessStartInfo CreateStartInfo(string fileName, IReadOnlyList<string> arguments)

--- a/UnityCtl.Cli/ExecutablePluginLoader.cs
+++ b/UnityCtl.Cli/ExecutablePluginLoader.cs
@@ -18,6 +18,7 @@ namespace UnityCtl.Cli;
 public static class ExecutablePluginLoader
 {
     private const string ExecutablePrefix = "unityctl-";
+    private static readonly string[] WindowsExecutableExtensions = [".exe", ".cmd", ".bat", ".ps1"];
 
     /// <summary>
     /// Discovers all executable plugins from PATH and plugin directories.
@@ -230,7 +231,8 @@ public static class ExecutablePluginLoader
         IEnumerable<string> files;
         try
         {
-            files = Directory.EnumerateFiles(directory);
+            // Use wildcard to filter at OS level instead of enumerating all files
+            files = Directory.EnumerateFiles(directory, "unityctl-*");
         }
         catch
         {
@@ -242,16 +244,12 @@ public static class ExecutablePluginLoader
             var fileName = Path.GetFileNameWithoutExtension(filePath);
             var extension = Path.GetExtension(filePath).ToLowerInvariant();
 
-            // On Windows, also match files with executable extensions
+            if (!fileName.StartsWith(ExecutablePrefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                // Match: unityctl-foo.exe, unityctl-foo.cmd, unityctl-foo.bat, unityctl-foo.ps1
-                var executableExtensions = new[] { ".exe", ".cmd", ".bat", ".ps1" };
-
-                if (!fileName.StartsWith(ExecutablePrefix, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                if (!executableExtensions.Contains(extension))
+                if (!WindowsExecutableExtensions.Contains(extension))
                     continue;
 
                 var name = fileName.Substring(ExecutablePrefix.Length);
@@ -267,15 +265,10 @@ public static class ExecutablePluginLoader
             }
             else
             {
-                // On Unix: match any executable file named unityctl-*
-                var fullFileName = Path.GetFileName(filePath);
-                if (!fullFileName.StartsWith(ExecutablePrefix, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                // Check if file is executable (has any execute bit)
                 if (!IsUnixExecutable(filePath))
                     continue;
 
+                var fullFileName = Path.GetFileName(filePath);
                 var name = fullFileName.Substring(ExecutablePrefix.Length);
                 // Strip extension if present (e.g., unityctl-foo.sh → foo)
                 var dotIndex = name.IndexOf('.');

--- a/UnityCtl.Cli/ExecutablePluginLoader.cs
+++ b/UnityCtl.Cli/ExecutablePluginLoader.cs
@@ -65,6 +65,22 @@ public static class ExecutablePluginLoader
     {
         var executableName = $"{ExecutablePrefix}{name}";
 
+        // Inject environment variables (best-effort, no InvocationContext available)
+        var envVars = new Dictionary<string, string>();
+        var projectRoot = ProjectLocator.FindProjectRoot();
+        if (projectRoot != null)
+        {
+            envVars["UNITYCTL_PROJECT_PATH"] = projectRoot;
+            var bridgeConfig = ProjectLocator.ReadBridgeConfig(projectRoot);
+            if (bridgeConfig != null)
+            {
+                envVars["UNITYCTL_BRIDGE_PORT"] = bridgeConfig.Port.ToString();
+                envVars["UNITYCTL_BRIDGE_URL"] = $"http://localhost:{bridgeConfig.Port}";
+            }
+        }
+
+        // Try to start "unityctl-<name>" directly. On Unix the OS resolves PATH.
+        // On Windows with UseShellExecute=false, this finds .exe files on PATH.
         var startInfo = new ProcessStartInfo
         {
             FileName = executableName,
@@ -77,18 +93,8 @@ public static class ExecutablePluginLoader
         foreach (var token in passThrough)
             startInfo.ArgumentList.Add(token);
 
-        // Inject environment variables (best-effort, no InvocationContext available)
-        var projectRoot = ProjectLocator.FindProjectRoot();
-        if (projectRoot != null)
-        {
-            startInfo.Environment["UNITYCTL_PROJECT_PATH"] = projectRoot;
-            var bridgeConfig = ProjectLocator.ReadBridgeConfig(projectRoot);
-            if (bridgeConfig != null)
-            {
-                startInfo.Environment["UNITYCTL_BRIDGE_PORT"] = bridgeConfig.Port.ToString();
-                startInfo.Environment["UNITYCTL_BRIDGE_URL"] = $"http://localhost:{bridgeConfig.Port}";
-            }
-        }
+        foreach (var (key, value) in envVars)
+            startInfo.Environment[key] = value;
 
         try
         {
@@ -106,9 +112,81 @@ public static class ExecutablePluginLoader
         }
         catch (System.ComponentModel.Win32Exception)
         {
-            // Executable not found on PATH
-            return null;
+            // Not found as a direct executable
         }
+
+        // On Windows, .bat/.cmd scripts need cmd.exe /c to run.
+        // Use PATHEXT-aware lookup via "where" to find the exact path first,
+        // so we don't blindly invoke cmd.exe for non-existent commands.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            string? resolvedPath = null;
+            try
+            {
+                var whereInfo = new ProcessStartInfo
+                {
+                    FileName = "where.exe",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+                whereInfo.ArgumentList.Add(executableName);
+
+                using var whereProc = Process.Start(whereInfo);
+                if (whereProc != null)
+                {
+                    resolvedPath = (await whereProc.StandardOutput.ReadLineAsync())?.Trim();
+                    await whereProc.WaitForExitAsync();
+                    if (whereProc.ExitCode != 0)
+                        resolvedPath = null;
+                }
+            }
+            catch
+            {
+                // where.exe not available — give up
+            }
+
+            if (resolvedPath != null)
+            {
+                var cmdInfo = new ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+                cmdInfo.ArgumentList.Add("/c");
+                cmdInfo.ArgumentList.Add(resolvedPath);
+
+                foreach (var token in passThrough)
+                    cmdInfo.ArgumentList.Add(token);
+
+                foreach (var (key, value) in envVars)
+                    cmdInfo.Environment[key] = value;
+
+                try
+                {
+                    using var process = Process.Start(cmdInfo);
+                    if (process != null)
+                    {
+                        var stdoutTask = StreamOutputAsync(process.StandardOutput, Console.Out);
+                        var stderrTask = StreamOutputAsync(process.StandardError, Console.Error);
+
+                        await Task.WhenAll(stdoutTask, stderrTask);
+                        await process.WaitForExitAsync();
+                        return process.ExitCode;
+                    }
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    // Resolved path but still couldn't execute
+                }
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/UnityCtl.Cli/PluginCommands.cs
+++ b/UnityCtl.Cli/PluginCommands.cs
@@ -12,13 +12,21 @@ namespace UnityCtl.Cli;
 
 public static class PluginCommands
 {
-    private static readonly Regex ValidPluginName = new(@"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", RegexOptions.Compiled);
+    internal static readonly Regex ValidPluginName = new(@"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", RegexOptions.Compiled);
 
     /// <summary>
-    /// Built-in command names, populated at startup from rootCommand.Children
+    /// Built-in command names, populated once at startup from rootCommand.Children
     /// so it stays in sync automatically when new commands are added.
     /// </summary>
-    internal static ISet<string> BuiltInCommandNames { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    internal static ISet<string> BuiltInCommandNames { get; private set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Initializes the built-in command names. Must be called once at startup before plugin discovery.
+    /// </summary>
+    internal static void InitializeBuiltInCommandNames(ISet<string> names)
+    {
+        BuiltInCommandNames = names ?? throw new ArgumentNullException(nameof(names));
+    }
 
     public static Command CreateCommand()
     {
@@ -272,6 +280,26 @@ public class Script
         {
             var name = context.ParseResult.GetValueForArgument(nameArgument);
             var json = ContextHelper.GetJson(context);
+
+            if (!ValidPluginName.IsMatch(name))
+            {
+                if (json)
+                {
+                    Console.WriteLine(JsonHelper.Serialize(new
+                    {
+                        success = false,
+                        error = "invalid_name",
+                        name,
+                        message = "Invalid plugin name."
+                    }));
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Error: Invalid plugin name '{name}'.");
+                }
+                context.ExitCode = 1;
+                return;
+            }
 
             // Find the plugin
             var plugins = PluginLoader.DiscoverPlugins();

--- a/UnityCtl.Cli/PluginCommands.cs
+++ b/UnityCtl.Cli/PluginCommands.cs
@@ -4,6 +4,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using UnityCtl.Protocol;
 
@@ -15,6 +16,8 @@ public static class PluginCommands
     /// Built-in command names, populated at startup from rootCommand.Children
     /// so it stays in sync automatically when new commands are added.
     /// </summary>
+    private static readonly Regex ValidPluginName = new(@"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", RegexOptions.Compiled);
+
     internal static ISet<string> BuiltInCommandNames { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     public static Command CreateCommand()
@@ -42,7 +45,7 @@ public static class PluginCommands
             var excludeNames = new HashSet<string>(BuiltInCommandNames, StringComparer.OrdinalIgnoreCase);
             foreach (var sp in scriptPlugins)
                 excludeNames.Add(sp.Manifest.Name);
-            var executablePlugins = ExecutablePluginLoader.DiscoverExecutablePlugins(excludeNames);
+            var executablePlugins = ExecutablePluginLoader.DiscoverExecutablePlugins(excludeNames, includePath: true);
 
             if (json)
             {
@@ -130,6 +133,28 @@ public static class PluginCommands
             var name = context.ParseResult.GetValueForArgument(nameArgument);
             var global = context.ParseResult.GetValueForOption(globalOption);
             var json = ContextHelper.GetJson(context);
+
+            if (!ValidPluginName.IsMatch(name))
+            {
+                if (json)
+                {
+                    Console.WriteLine(JsonHelper.Serialize(new
+                    {
+                        success = false,
+                        error = "invalid_name",
+                        name,
+                        message = "Plugin name must contain only lowercase letters, digits, and hyphens, and must start and end with a letter or digit."
+                    }));
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Error: Invalid plugin name '{name}'.");
+                    Console.Error.WriteLine("Plugin name must contain only lowercase letters, digits, and hyphens,");
+                    Console.Error.WriteLine("and must start and end with a letter or digit.");
+                }
+                context.ExitCode = 1;
+                return;
+            }
 
             var pluginsDir = global
                 ? PluginLoader.GetUserPluginsDirectory()
@@ -226,11 +251,19 @@ public class Script
 
         var nameArgument = new Argument<string>("name", "Plugin name to remove");
 
+        var forceOption = new Option<bool>(
+            "--force",
+            "Remove without confirmation"
+        );
+        forceOption.AddAlias("-f");
+
         removeCommand.AddArgument(nameArgument);
+        removeCommand.AddOption(forceOption);
 
         removeCommand.SetHandler((InvocationContext context) =>
         {
             var name = context.ParseResult.GetValueForArgument(nameArgument);
+            var force = context.ParseResult.GetValueForOption(forceOption);
             var json = ContextHelper.GetJson(context);
 
             // Find the plugin
@@ -255,6 +288,19 @@ public class Script
                 }
                 context.ExitCode = 1;
                 return;
+            }
+
+            // Confirm removal unless --force or --json
+            if (!force && !json)
+            {
+                Console.WriteLine($"Remove plugin '{plugin.Manifest.Name}' from: {ContextHelper.FormatPath(plugin.Directory)}");
+                Console.Write("Are you sure? [y/N]: ");
+                var response = Console.ReadLine()?.Trim().ToLowerInvariant();
+                if (response != "y" && response != "yes")
+                {
+                    Console.WriteLine("Aborted.");
+                    return;
+                }
             }
 
             // Delete plugin directory

--- a/UnityCtl.Cli/PluginCommands.cs
+++ b/UnityCtl.Cli/PluginCommands.cs
@@ -12,12 +12,12 @@ namespace UnityCtl.Cli;
 
 public static class PluginCommands
 {
+    private static readonly Regex ValidPluginName = new(@"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", RegexOptions.Compiled);
+
     /// <summary>
     /// Built-in command names, populated at startup from rootCommand.Children
     /// so it stays in sync automatically when new commands are added.
     /// </summary>
-    private static readonly Regex ValidPluginName = new(@"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", RegexOptions.Compiled);
-
     internal static ISet<string> BuiltInCommandNames { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     public static Command CreateCommand()
@@ -151,6 +151,26 @@ public static class PluginCommands
                 return;
             }
 
+            if (BuiltInCommandNames.Contains(name))
+            {
+                if (json)
+                {
+                    Console.WriteLine(JsonHelper.Serialize(new
+                    {
+                        success = false,
+                        error = "name_conflict",
+                        name,
+                        message = $"'{name}' conflicts with a built-in command."
+                    }));
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Error: '{name}' conflicts with a built-in command.");
+                }
+                context.ExitCode = 1;
+                return;
+            }
+
             var pluginsDir = global
                 ? PluginLoader.GetUserPluginsDirectory()
                 : PluginLoader.GetProjectPluginsDirectoryOrDefault();
@@ -260,18 +280,45 @@ public class Script
 
             if (plugin == null)
             {
+                // Check if it's an executable plugin (which can't be removed automatically)
+                var execPlugins = ExecutablePluginLoader.DiscoverExecutablePlugins(includePath: true);
+                var execMatch = execPlugins.FirstOrDefault(p =>
+                    string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+
                 if (json)
                 {
-                    Console.WriteLine(JsonHelper.Serialize(new
+                    if (execMatch != null)
                     {
-                        success = false,
-                        error = "not_found",
-                        name
-                    }));
+                        Console.WriteLine(JsonHelper.Serialize(new
+                        {
+                            success = false,
+                            error = "executable_plugin",
+                            name,
+                            path = execMatch.Path,
+                            message = "Executable plugins must be removed manually."
+                        }));
+                    }
+                    else
+                    {
+                        Console.WriteLine(JsonHelper.Serialize(new
+                        {
+                            success = false,
+                            error = "not_found",
+                            name
+                        }));
+                    }
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Error: Plugin '{name}' not found.");
+                    if (execMatch != null)
+                    {
+                        Console.Error.WriteLine($"Error: '{name}' is an executable plugin and must be removed manually.");
+                        Console.Error.WriteLine($"  Path: {ContextHelper.FormatPath(execMatch.Path)}");
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"Error: Plugin '{name}' not found.");
+                    }
                 }
                 context.ExitCode = 1;
                 return;

--- a/UnityCtl.Cli/PluginCommands.cs
+++ b/UnityCtl.Cli/PluginCommands.cs
@@ -11,14 +11,11 @@ namespace UnityCtl.Cli;
 
 public static class PluginCommands
 {
-    // Built-in command names to exclude from executable plugin discovery
-    internal static readonly string[] BuiltInCommandNames =
-    [
-        "setup", "update", "config", "package", "skill", "plugin",
-        "status", "wait", "logs",
-        "bridge", "editor", "dialog",
-        "scene", "play", "asset", "menu", "test", "screenshot", "record", "script", "snapshot", "prefab"
-    ];
+    /// <summary>
+    /// Built-in command names, populated at startup from rootCommand.Children
+    /// so it stays in sync automatically when new commands are added.
+    /// </summary>
+    internal static ISet<string> BuiltInCommandNames { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     public static Command CreateCommand()
     {

--- a/UnityCtl.Cli/PluginCommands.cs
+++ b/UnityCtl.Cli/PluginCommands.cs
@@ -227,17 +227,19 @@ public static class PluginCommands
             File.WriteAllText(Path.Combine(pluginDir, "plugin.json"), manifestJson);
 
             // Write example script
-            var exampleScript = @"using UnityEngine;
+            var exampleScript = """
+                using UnityEngine;
 
-public class Script
-{
-    public static object Main(string[] args)
-    {
-        Debug.Log(""Hello from " + name + @" plugin!"");
-        return ""Hello from Unity!"";
-    }
-}
-";
+                public class Script
+                {
+                    public static object Main(string[] args)
+                    {
+                        Debug.Log("Hello from {{NAME}} plugin!");
+                        return "Hello from Unity!";
+                    }
+                }
+
+                """.Replace("{{NAME}}", name);
             File.WriteAllText(Path.Combine(pluginDir, "hello.cs"), exampleScript);
 
             if (json)

--- a/UnityCtl.Cli/PluginCommands.cs
+++ b/UnityCtl.Cli/PluginCommands.cs
@@ -11,6 +11,15 @@ namespace UnityCtl.Cli;
 
 public static class PluginCommands
 {
+    // Built-in command names to exclude from executable plugin discovery
+    internal static readonly string[] BuiltInCommandNames =
+    [
+        "setup", "update", "config", "package", "skill", "plugin",
+        "status", "wait", "logs",
+        "bridge", "editor", "dialog",
+        "scene", "play", "asset", "menu", "test", "screenshot", "record", "script", "snapshot", "prefab"
+    ];
+
     public static Command CreateCommand()
     {
         var pluginCommand = new Command("plugin", "Plugin management");
@@ -30,44 +39,72 @@ public static class PluginCommands
         listCommand.SetHandler((InvocationContext context) =>
         {
             var json = ContextHelper.GetJson(context);
-            var plugins = PluginLoader.DiscoverPlugins();
+            var scriptPlugins = PluginLoader.DiscoverPlugins();
+
+            // Exclude built-in command names and script plugin names from executable discovery
+            var excludeNames = new HashSet<string>(BuiltInCommandNames, StringComparer.OrdinalIgnoreCase);
+            foreach (var sp in scriptPlugins)
+                excludeNames.Add(sp.Manifest.Name);
+            var executablePlugins = ExecutablePluginLoader.DiscoverExecutablePlugins(excludeNames);
 
             if (json)
             {
-                var output = plugins.Select(p => new
+                var scriptOutput = scriptPlugins.Select(p => new
                 {
                     name = p.Manifest.Name,
+                    type = "script",
                     version = p.Manifest.Version,
                     description = p.Manifest.Description,
                     commands = p.Manifest.Commands.Select(c => c.Name).ToArray(),
                     source = p.Source,
                     directory = p.Directory
                 });
-                Console.WriteLine(JsonHelper.Serialize(output));
+                var execOutput = executablePlugins.Select(p => new
+                {
+                    name = p.Name,
+                    type = "executable",
+                    version = (string?)null,
+                    description = p.Description,
+                    commands = Array.Empty<string>(),
+                    source = p.Source,
+                    directory = Path.GetDirectoryName(p.Path)
+                });
+                Console.WriteLine(JsonHelper.Serialize(scriptOutput.Concat<object>(execOutput)));
             }
             else
             {
-                if (plugins.Count == 0)
+                var totalCount = scriptPlugins.Count + executablePlugins.Count;
+                if (totalCount == 0)
                 {
                     Console.WriteLine("No plugins installed.");
                     Console.WriteLine();
                     Console.WriteLine("Create one with: unityctl plugin create <name>");
+                    Console.WriteLine("Or place a 'unityctl-<name>' executable on PATH.");
                     return;
                 }
 
-                Console.WriteLine($"Installed plugins ({plugins.Count}):");
+                Console.WriteLine($"Installed plugins ({totalCount}):");
                 Console.WriteLine();
 
-                foreach (var plugin in plugins)
+                foreach (var plugin in scriptPlugins)
                 {
                     var version = plugin.Manifest.Version != null ? $" v{plugin.Manifest.Version}" : "";
                     var cmds = string.Join(", ", plugin.Manifest.Commands.Select(c => c.Name));
-                    Console.WriteLine($"  {plugin.Manifest.Name}{version} ({plugin.Source})");
+                    Console.WriteLine($"  {plugin.Manifest.Name}{version} [script] ({plugin.Source})");
                     if (!string.IsNullOrEmpty(plugin.Manifest.Description))
                         Console.WriteLine($"    {plugin.Manifest.Description}");
                     if (cmds.Length > 0)
                         Console.WriteLine($"    Commands: {cmds}");
                     Console.WriteLine($"    Path: {ContextHelper.FormatPath(plugin.Directory)}");
+                    Console.WriteLine();
+                }
+
+                foreach (var plugin in executablePlugins)
+                {
+                    Console.WriteLine($"  {plugin.Name} [executable] ({plugin.Source})");
+                    if (!string.IsNullOrEmpty(plugin.Description))
+                        Console.WriteLine($"    {plugin.Description}");
+                    Console.WriteLine($"    Path: {ContextHelper.FormatPath(plugin.Path)}");
                     Console.WriteLine();
                 }
             }

--- a/UnityCtl.Cli/PluginCommands.cs
+++ b/UnityCtl.Cli/PluginCommands.cs
@@ -251,19 +251,11 @@ public class Script
 
         var nameArgument = new Argument<string>("name", "Plugin name to remove");
 
-        var forceOption = new Option<bool>(
-            "--force",
-            "Remove without confirmation"
-        );
-        forceOption.AddAlias("-f");
-
         removeCommand.AddArgument(nameArgument);
-        removeCommand.AddOption(forceOption);
 
         removeCommand.SetHandler((InvocationContext context) =>
         {
             var name = context.ParseResult.GetValueForArgument(nameArgument);
-            var force = context.ParseResult.GetValueForOption(forceOption);
             var json = ContextHelper.GetJson(context);
 
             // Find the plugin
@@ -288,19 +280,6 @@ public class Script
                 }
                 context.ExitCode = 1;
                 return;
-            }
-
-            // Confirm removal unless --force or --json
-            if (!force && !json)
-            {
-                Console.WriteLine($"Remove plugin '{plugin.Manifest.Name}' from: {ContextHelper.FormatPath(plugin.Directory)}");
-                Console.Write("Are you sure? [y/N]: ");
-                var response = Console.ReadLine()?.Trim().ToLowerInvariant();
-                if (response != "y" && response != "yes")
-                {
-                    Console.WriteLine("Aborted.");
-                    return;
-                }
             }
 
             // Delete plugin directory

--- a/UnityCtl.Cli/PluginCommands.cs
+++ b/UnityCtl.Cli/PluginCommands.cs
@@ -39,12 +39,7 @@ public static class PluginCommands
         listCommand.SetHandler((InvocationContext context) =>
         {
             var json = ContextHelper.GetJson(context);
-            var scriptPlugins = PluginLoader.DiscoverPlugins();
-
-            // Exclude built-in command names and script plugin names from executable discovery
-            var excludeNames = new HashSet<string>(BuiltInCommandNames, StringComparer.OrdinalIgnoreCase);
-            foreach (var sp in scriptPlugins)
-                excludeNames.Add(sp.Manifest.Name);
+            var (scriptPlugins, excludeNames) = PluginLoader.DiscoverWithExclusions(BuiltInCommandNames);
             var executablePlugins = ExecutablePluginLoader.DiscoverExecutablePlugins(excludeNames, includePath: true);
 
             if (json)

--- a/UnityCtl.Cli/PluginCommands.cs
+++ b/UnityCtl.Cli/PluginCommands.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using UnityCtl.Protocol;
+
+namespace UnityCtl.Cli;
+
+public static class PluginCommands
+{
+    public static Command CreateCommand()
+    {
+        var pluginCommand = new Command("plugin", "Plugin management");
+
+        pluginCommand.AddCommand(CreateListCommand());
+        pluginCommand.AddCommand(CreateCreateCommand());
+        pluginCommand.AddCommand(CreateRemoveCommand());
+
+        return pluginCommand;
+    }
+
+    private static Command CreateListCommand()
+    {
+        var listCommand = new Command("list", "List installed plugins");
+        listCommand.AddAlias("ls");
+
+        listCommand.SetHandler((InvocationContext context) =>
+        {
+            var json = ContextHelper.GetJson(context);
+            var plugins = PluginLoader.DiscoverPlugins();
+
+            if (json)
+            {
+                var output = plugins.Select(p => new
+                {
+                    name = p.Manifest.Name,
+                    version = p.Manifest.Version,
+                    description = p.Manifest.Description,
+                    commands = p.Manifest.Commands.Select(c => c.Name).ToArray(),
+                    source = p.Source,
+                    directory = p.Directory
+                });
+                Console.WriteLine(JsonHelper.Serialize(output));
+            }
+            else
+            {
+                if (plugins.Count == 0)
+                {
+                    Console.WriteLine("No plugins installed.");
+                    Console.WriteLine();
+                    Console.WriteLine("Create one with: unityctl plugin create <name>");
+                    return;
+                }
+
+                Console.WriteLine($"Installed plugins ({plugins.Count}):");
+                Console.WriteLine();
+
+                foreach (var plugin in plugins)
+                {
+                    var version = plugin.Manifest.Version != null ? $" v{plugin.Manifest.Version}" : "";
+                    var cmds = string.Join(", ", plugin.Manifest.Commands.Select(c => c.Name));
+                    Console.WriteLine($"  {plugin.Manifest.Name}{version} ({plugin.Source})");
+                    if (!string.IsNullOrEmpty(plugin.Manifest.Description))
+                        Console.WriteLine($"    {plugin.Manifest.Description}");
+                    if (cmds.Length > 0)
+                        Console.WriteLine($"    Commands: {cmds}");
+                    Console.WriteLine($"    Path: {ContextHelper.FormatPath(plugin.Directory)}");
+                    Console.WriteLine();
+                }
+            }
+        });
+
+        return listCommand;
+    }
+
+    private static Command CreateCreateCommand()
+    {
+        var createCommand = new Command("create", "Scaffold a new plugin");
+
+        var nameArgument = new Argument<string>("name", "Plugin name");
+
+        var globalOption = new Option<bool>(
+            "--global",
+            "Create in user-level ~/.unityctl/plugins/ instead of project-level"
+        );
+        globalOption.AddAlias("-g");
+
+        createCommand.AddArgument(nameArgument);
+        createCommand.AddOption(globalOption);
+
+        createCommand.SetHandler((InvocationContext context) =>
+        {
+            var name = context.ParseResult.GetValueForArgument(nameArgument);
+            var global = context.ParseResult.GetValueForOption(globalOption);
+            var json = ContextHelper.GetJson(context);
+
+            var pluginsDir = global
+                ? PluginLoader.GetUserPluginsDirectory()
+                : PluginLoader.GetProjectPluginsDirectoryOrDefault();
+
+            var pluginDir = Path.Combine(pluginsDir, name);
+
+            if (Directory.Exists(pluginDir))
+            {
+                if (json)
+                {
+                    Console.WriteLine(JsonHelper.Serialize(new
+                    {
+                        success = false,
+                        error = "already_exists",
+                        path = pluginDir
+                    }));
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Error: Plugin '{name}' already exists at: {pluginDir}");
+                }
+                context.ExitCode = 1;
+                return;
+            }
+
+            Directory.CreateDirectory(pluginDir);
+
+            // Write plugin.json
+            var manifest = new PluginManifest
+            {
+                Name = name,
+                Version = "1.0.0",
+                Description = $"{name} plugin",
+                Commands = new[]
+                {
+                    new PluginCommandDefinition
+                    {
+                        Name = "hello",
+                        Description = "Say hello from Unity",
+                        Handler = new PluginHandler { Type = "script", File = "hello.cs" }
+                    }
+                }
+            };
+
+            var manifestJson = JsonConvert.SerializeObject(manifest, Formatting.Indented);
+            File.WriteAllText(Path.Combine(pluginDir, "plugin.json"), manifestJson);
+
+            // Write example script
+            var exampleScript = @"using UnityEngine;
+
+public class Script
+{
+    public static object Main(string[] args)
+    {
+        Debug.Log(""Hello from " + name + @" plugin!"");
+        return ""Hello from Unity!"";
+    }
+}
+";
+            File.WriteAllText(Path.Combine(pluginDir, "hello.cs"), exampleScript);
+
+            if (json)
+            {
+                Console.WriteLine(JsonHelper.Serialize(new
+                {
+                    success = true,
+                    name,
+                    path = pluginDir,
+                    source = global ? "user" : "project"
+                }));
+            }
+            else
+            {
+                Console.WriteLine($"Created plugin '{name}' at: {ContextHelper.FormatPath(pluginDir)}");
+                Console.WriteLine();
+                Console.WriteLine("Files created:");
+                Console.WriteLine($"  plugin.json  - Plugin manifest");
+                Console.WriteLine($"  hello.cs     - Example command script");
+                Console.WriteLine();
+                Console.WriteLine($"Try it: unityctl {name} hello");
+                Console.WriteLine();
+                Console.WriteLine("Run 'unityctl skill rebuild' to update the Claude Code skill.");
+            }
+        });
+
+        return createCommand;
+    }
+
+    private static Command CreateRemoveCommand()
+    {
+        var removeCommand = new Command("remove", "Remove a plugin");
+        removeCommand.AddAlias("rm");
+
+        var nameArgument = new Argument<string>("name", "Plugin name to remove");
+
+        removeCommand.AddArgument(nameArgument);
+
+        removeCommand.SetHandler((InvocationContext context) =>
+        {
+            var name = context.ParseResult.GetValueForArgument(nameArgument);
+            var json = ContextHelper.GetJson(context);
+
+            // Find the plugin
+            var plugins = PluginLoader.DiscoverPlugins();
+            var plugin = plugins.FirstOrDefault(p =>
+                string.Equals(p.Manifest.Name, name, StringComparison.OrdinalIgnoreCase));
+
+            if (plugin == null)
+            {
+                if (json)
+                {
+                    Console.WriteLine(JsonHelper.Serialize(new
+                    {
+                        success = false,
+                        error = "not_found",
+                        name
+                    }));
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Error: Plugin '{name}' not found.");
+                }
+                context.ExitCode = 1;
+                return;
+            }
+
+            // Delete plugin directory
+            Directory.Delete(plugin.Directory, recursive: true);
+
+            if (json)
+            {
+                Console.WriteLine(JsonHelper.Serialize(new
+                {
+                    success = true,
+                    name = plugin.Manifest.Name,
+                    path = plugin.Directory
+                }));
+            }
+            else
+            {
+                Console.WriteLine($"Removed plugin '{plugin.Manifest.Name}' from: {ContextHelper.FormatPath(plugin.Directory)}");
+                Console.WriteLine();
+                Console.WriteLine("Run 'unityctl skill rebuild' to update the Claude Code skill.");
+            }
+        });
+
+        return removeCommand;
+    }
+}

--- a/UnityCtl.Cli/PluginLoader.cs
+++ b/UnityCtl.Cli/PluginLoader.cs
@@ -4,6 +4,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using UnityCtl.Protocol;
@@ -123,7 +124,11 @@ public static class PluginLoader
 
         // Read the script file (validate path stays within plugin directory)
         var scriptPath = Path.GetFullPath(Path.Combine(pluginDir, handlerFile));
-        if (!scriptPath.StartsWith(Path.GetFullPath(pluginDir) + Path.DirectorySeparatorChar))
+        var resolvedPluginDir = Path.GetFullPath(pluginDir) + Path.DirectorySeparatorChar;
+        var pathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (!scriptPath.StartsWith(resolvedPluginDir, pathComparison))
         {
             Console.Error.WriteLine($"Error: Plugin script path escapes plugin directory: {handlerFile}");
             context.ExitCode = 1;
@@ -274,7 +279,11 @@ public static class PluginLoader
         if (plugin.Manifest.Skill != null)
         {
             var skillPath = Path.GetFullPath(Path.Combine(plugin.Directory, plugin.Manifest.Skill.File));
-            if (skillPath.StartsWith(Path.GetFullPath(plugin.Directory) + Path.DirectorySeparatorChar)
+            var resolvedDir = Path.GetFullPath(plugin.Directory) + Path.DirectorySeparatorChar;
+            var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            if (skillPath.StartsWith(resolvedDir, comparison)
                 && File.Exists(skillPath))
                 return File.ReadAllText(skillPath);
         }

--- a/UnityCtl.Cli/PluginLoader.cs
+++ b/UnityCtl.Cli/PluginLoader.cs
@@ -121,8 +121,14 @@ public static class PluginLoader
         var json = ContextHelper.GetJson(context);
         var timeout = ContextHelper.GetTimeout(context);
 
-        // Read the script file
-        var scriptPath = Path.Combine(pluginDir, handlerFile);
+        // Read the script file (validate path stays within plugin directory)
+        var scriptPath = Path.GetFullPath(Path.Combine(pluginDir, handlerFile));
+        if (!scriptPath.StartsWith(Path.GetFullPath(pluginDir) + Path.DirectorySeparatorChar))
+        {
+            Console.Error.WriteLine($"Error: Plugin script path escapes plugin directory: {handlerFile}");
+            context.ExitCode = 1;
+            return;
+        }
         if (!File.Exists(scriptPath))
         {
             Console.Error.WriteLine($"Error: Plugin script not found: {scriptPath}");
@@ -267,8 +273,9 @@ public static class PluginLoader
         // Check for custom skill section file
         if (plugin.Manifest.Skill != null)
         {
-            var skillPath = Path.Combine(plugin.Directory, plugin.Manifest.Skill.File);
-            if (File.Exists(skillPath))
+            var skillPath = Path.GetFullPath(Path.Combine(plugin.Directory, plugin.Manifest.Skill.File));
+            if (skillPath.StartsWith(Path.GetFullPath(plugin.Directory) + Path.DirectorySeparatorChar)
+                && File.Exists(skillPath))
                 return File.ReadAllText(skillPath);
         }
 

--- a/UnityCtl.Cli/PluginLoader.cs
+++ b/UnityCtl.Cli/PluginLoader.cs
@@ -181,73 +181,40 @@ public static class PluginLoader
             return;
         }
 
-        // Display result
-        if (json)
-        {
-            Console.WriteLine(JsonHelper.Serialize(response.Result));
-        }
-        else
-        {
-            var resultJson = JsonConvert.SerializeObject(response.Result, JsonHelper.Settings);
-            var result = JsonConvert.DeserializeObject<ScriptExecuteResult>(resultJson, JsonHelper.Settings);
-            if (result != null)
-            {
-                if (result.Success)
-                {
-                    if (result.Result != null)
-                        Console.WriteLine(result.Result);
-                }
-                else
-                {
-                    Console.Error.WriteLine($"Execution failed: {result.Error}");
-                    if (result.Diagnostics != null)
-                    {
-                        foreach (var d in result.Diagnostics)
-                            Console.Error.WriteLine($"  {d}");
-                    }
-                    context.ExitCode = 1;
-                }
-            }
-        }
+        ScriptCommands.DisplayScriptResult(context, response, json);
     }
 
-    public static string? GetProjectPluginsDirectory()
+    /// <summary>
+    /// Walks up from CWD to find the nearest .unityctl/ directory.
+    /// Returns null if none found.
+    /// </summary>
+    public static string? FindDotUnityctlDirectory()
     {
-        // Walk up from CWD looking for .unityctl/plugins/
         var current = new DirectoryInfo(Directory.GetCurrentDirectory());
         while (current != null)
         {
-            var pluginsDir = Path.Combine(current.FullName, ".unityctl", PluginDirName);
-            if (Directory.Exists(pluginsDir))
-                return pluginsDir;
-
-            // Also check if .unityctl exists (even without plugins yet)
-            var unityctlDir = Path.Combine(current.FullName, ".unityctl");
-            if (Directory.Exists(unityctlDir))
-            {
-                var candidate = Path.Combine(unityctlDir, PluginDirName);
-                return Directory.Exists(candidate) ? candidate : null;
-            }
-
+            var candidate = Path.Combine(current.FullName, ".unityctl");
+            if (Directory.Exists(candidate))
+                return candidate;
             current = current.Parent;
         }
         return null;
     }
 
+    public static string? GetProjectPluginsDirectory()
+    {
+        var dotUnityctl = FindDotUnityctlDirectory();
+        if (dotUnityctl == null) return null;
+
+        var pluginsDir = Path.Combine(dotUnityctl, PluginDirName);
+        return Directory.Exists(pluginsDir) ? pluginsDir : null;
+    }
+
     public static string GetProjectPluginsDirectoryOrDefault()
     {
-        // Walk up from CWD looking for .unityctl/
-        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
-        while (current != null)
-        {
-            var unityctlDir = Path.Combine(current.FullName, ".unityctl");
-            if (Directory.Exists(unityctlDir))
-                return Path.Combine(unityctlDir, PluginDirName);
-            current = current.Parent;
-        }
-
-        // Fallback: .unityctl/plugins in CWD
-        return Path.Combine(Directory.GetCurrentDirectory(), ".unityctl", PluginDirName);
+        var dotUnityctl = FindDotUnityctlDirectory()
+            ?? Path.Combine(Directory.GetCurrentDirectory(), ".unityctl");
+        return Path.Combine(dotUnityctl, PluginDirName);
     }
 
     public static string GetUserPluginsDirectory()

--- a/UnityCtl.Cli/PluginLoader.cs
+++ b/UnityCtl.Cli/PluginLoader.cs
@@ -34,6 +34,19 @@ public static class PluginLoader
     }
 
     /// <summary>
+    /// Returns plugin directories in precedence order (user-level first, project-level second).
+    /// Higher-precedence entries appear later so they overwrite earlier ones in dictionary-based merges.
+    /// </summary>
+    public static IEnumerable<(string Path, string Source)> GetPluginDirectories()
+    {
+        yield return (GetUserPluginsDirectory(), "user");
+
+        var projectDir = GetProjectPluginsDirectory();
+        if (projectDir != null)
+            yield return (projectDir, "project");
+    }
+
+    /// <summary>
     /// Discovers all plugins from both project-level and user-level directories.
     /// Project-level plugins override user-level plugins with the same name.
     /// </summary>
@@ -41,16 +54,9 @@ public static class PluginLoader
     {
         var plugins = new Dictionary<string, LoadedPlugin>(StringComparer.OrdinalIgnoreCase);
 
-        // User-level first (lower precedence)
-        var userDir = GetUserPluginsDirectory();
-        foreach (var plugin in LoadPluginsFromDirectory(userDir, "user"))
-            plugins[plugin.Manifest.Name] = plugin;
-
-        // Project-level second (higher precedence, overwrites user-level)
-        var projectDir = GetProjectPluginsDirectory();
-        if (projectDir != null)
+        foreach (var (dir, source) in GetPluginDirectories())
         {
-            foreach (var plugin in LoadPluginsFromDirectory(projectDir, "project"))
+            foreach (var plugin in LoadPluginsFromDirectory(dir, source))
                 plugins[plugin.Manifest.Name] = plugin;
         }
 
@@ -213,7 +219,11 @@ public static class PluginLoader
     /// </summary>
     public static bool IsPathWithin(string directory, string filePath)
     {
-        var resolvedFile = Path.GetFullPath(Path.Combine(directory, filePath));
+        // Normalize backslashes to forward slashes on all platforms so that a manifest
+        // authored on Windows (using "subdir\file.cs") is still validated correctly on Unix
+        // where backslash is not a path separator.
+        var normalizedFile = filePath.Replace('\\', '/');
+        var resolvedFile = Path.GetFullPath(Path.Combine(directory, normalizedFile));
         var resolvedDir = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
             + Path.DirectorySeparatorChar;
         var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/UnityCtl.Cli/PluginLoader.cs
+++ b/UnityCtl.Cli/PluginLoader.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using UnityCtl.Protocol;
+
+namespace UnityCtl.Cli;
+
+/// <summary>
+/// Discovers and loads plugins from .unityctl/plugins/ (project-level) and ~/.unityctl/plugins/ (user-level).
+/// Project-level plugins take precedence over user-level plugins with the same name.
+/// </summary>
+public static class PluginLoader
+{
+    public const string PluginDirName = "plugins";
+    public const string ManifestFileName = "plugin.json";
+
+    /// <summary>
+    /// Discovers all plugins from both project-level and user-level directories.
+    /// Project-level plugins override user-level plugins with the same name.
+    /// </summary>
+    public static List<LoadedPlugin> DiscoverPlugins()
+    {
+        var plugins = new Dictionary<string, LoadedPlugin>(StringComparer.OrdinalIgnoreCase);
+
+        // User-level first (lower precedence)
+        var userDir = GetUserPluginsDirectory();
+        if (userDir != null)
+        {
+            foreach (var plugin in LoadPluginsFromDirectory(userDir, "user"))
+                plugins[plugin.Manifest.Name] = plugin;
+        }
+
+        // Project-level second (higher precedence, overwrites user-level)
+        var projectDir = GetProjectPluginsDirectory();
+        if (projectDir != null)
+        {
+            foreach (var plugin in LoadPluginsFromDirectory(projectDir, "project"))
+                plugins[plugin.Manifest.Name] = plugin;
+        }
+
+        return plugins.Values.ToList();
+    }
+
+    /// <summary>
+    /// Creates System.CommandLine commands from a loaded plugin manifest.
+    /// Each plugin becomes a top-level command with subcommands from the manifest.
+    /// </summary>
+    public static Command CreateCommandFromPlugin(LoadedPlugin plugin)
+    {
+        var pluginCommand = new Command(
+            plugin.Manifest.Name,
+            plugin.Manifest.Description ?? $"Plugin: {plugin.Manifest.Name}"
+        );
+
+        foreach (var cmdDef in plugin.Manifest.Commands)
+        {
+            var subCommand = new Command(cmdDef.Name, cmdDef.Description ?? cmdDef.Name);
+
+            // Add arguments
+            var argObjects = new List<Argument<string>>();
+            foreach (var argDef in cmdDef.Arguments)
+            {
+                var arg = argDef.Required
+                    ? new Argument<string>(argDef.Name, argDef.Description ?? argDef.Name)
+                    : new Argument<string>(argDef.Name, getDefaultValue: () => string.Empty, description: argDef.Description ?? argDef.Name);
+                subCommand.AddArgument(arg);
+                argObjects.Add(arg);
+            }
+
+            // Add options
+            var optObjects = new List<(string Name, Option Option, string Type)>();
+            foreach (var optDef in cmdDef.Options)
+            {
+                var optName = optDef.Name.StartsWith('-') ? optDef.Name : $"--{optDef.Name}";
+
+                if (optDef.Type == "bool")
+                {
+                    var opt = new Option<bool>(optName, optDef.Description ?? optDef.Name);
+                    subCommand.AddOption(opt);
+                    optObjects.Add((optDef.Name, opt, "bool"));
+                }
+                else
+                {
+                    var opt = new Option<string?>(optName, optDef.Description ?? optDef.Name);
+                    subCommand.AddOption(opt);
+                    optObjects.Add((optDef.Name, opt, "string"));
+                }
+            }
+
+            // Capture for closure
+            var handlerFile = cmdDef.Handler.File;
+            var pluginDir = plugin.Directory;
+            var capturedArgs = argObjects.ToList();
+            var capturedOpts = optObjects.ToList();
+
+            subCommand.SetHandler(async (InvocationContext context) =>
+            {
+                await ExecutePluginCommandAsync(context, pluginDir, handlerFile, capturedArgs, capturedOpts);
+            });
+
+            pluginCommand.AddCommand(subCommand);
+        }
+
+        return pluginCommand;
+    }
+
+    private static async Task ExecutePluginCommandAsync(
+        InvocationContext context,
+        string pluginDir,
+        string handlerFile,
+        List<Argument<string>> args,
+        List<(string Name, Option Option, string Type)> opts)
+    {
+        var projectPath = ContextHelper.GetProjectPath(context);
+        var agentId = ContextHelper.GetAgentId(context);
+        var json = ContextHelper.GetJson(context);
+        var timeout = ContextHelper.GetTimeout(context);
+
+        // Read the script file
+        var scriptPath = Path.Combine(pluginDir, handlerFile);
+        if (!File.Exists(scriptPath))
+        {
+            Console.Error.WriteLine($"Error: Plugin script not found: {scriptPath}");
+            context.ExitCode = 1;
+            return;
+        }
+
+        var csharpCode = await File.ReadAllTextAsync(scriptPath);
+
+        // Build scriptArgs from plugin arguments and options
+        var scriptArgs = new List<string>();
+        foreach (var arg in args)
+        {
+            var value = context.ParseResult.GetValueForArgument(arg);
+            if (!string.IsNullOrEmpty(value))
+                scriptArgs.Add(value);
+        }
+        foreach (var (name, opt, type) in opts)
+        {
+            if (type == "bool")
+            {
+                var boolOpt = (Option<bool>)opt;
+                if (context.ParseResult.GetValueForOption(boolOpt))
+                    scriptArgs.Add($"--{name}");
+            }
+            else
+            {
+                var strOpt = (Option<string?>)opt;
+                var value = context.ParseResult.GetValueForOption(strOpt);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    scriptArgs.Add($"--{name}");
+                    scriptArgs.Add(value);
+                }
+            }
+        }
+
+        var client = BridgeClient.TryCreateFromProject(projectPath, agentId);
+        if (client == null) { context.ExitCode = 1; return; }
+
+        var rpcArgs = new Dictionary<string, object?>
+        {
+            { "code", csharpCode },
+            { "className", "Script" },
+            { "methodName", "Main" },
+            { "scriptArgs", scriptArgs.ToArray() }
+        };
+
+        var response = await client.SendCommandAsync(UnityCtlCommands.ScriptExecute, rpcArgs, timeout);
+        if (response == null) { context.ExitCode = 1; return; }
+
+        if (response.Status == ResponseStatus.Error)
+        {
+            Console.Error.WriteLine($"Error: {response.Error?.Message}");
+            context.ExitCode = 1;
+            return;
+        }
+
+        // Display result
+        if (json)
+        {
+            Console.WriteLine(JsonHelper.Serialize(response.Result));
+        }
+        else
+        {
+            var resultJson = JsonConvert.SerializeObject(response.Result, JsonHelper.Settings);
+            var result = JsonConvert.DeserializeObject<ScriptExecuteResult>(resultJson, JsonHelper.Settings);
+            if (result != null)
+            {
+                if (result.Success)
+                {
+                    if (result.Result != null)
+                        Console.WriteLine(result.Result);
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Execution failed: {result.Error}");
+                    if (result.Diagnostics != null)
+                    {
+                        foreach (var d in result.Diagnostics)
+                            Console.Error.WriteLine($"  {d}");
+                    }
+                    context.ExitCode = 1;
+                }
+            }
+        }
+    }
+
+    public static string? GetProjectPluginsDirectory()
+    {
+        // Walk up from CWD looking for .unityctl/plugins/
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current != null)
+        {
+            var pluginsDir = Path.Combine(current.FullName, ".unityctl", PluginDirName);
+            if (Directory.Exists(pluginsDir))
+                return pluginsDir;
+
+            // Also check if .unityctl exists (even without plugins yet)
+            var unityctlDir = Path.Combine(current.FullName, ".unityctl");
+            if (Directory.Exists(unityctlDir))
+            {
+                var candidate = Path.Combine(unityctlDir, PluginDirName);
+                return Directory.Exists(candidate) ? candidate : null;
+            }
+
+            current = current.Parent;
+        }
+        return null;
+    }
+
+    public static string GetProjectPluginsDirectoryOrDefault()
+    {
+        // Walk up from CWD looking for .unityctl/
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current != null)
+        {
+            var unityctlDir = Path.Combine(current.FullName, ".unityctl");
+            if (Directory.Exists(unityctlDir))
+                return Path.Combine(unityctlDir, PluginDirName);
+            current = current.Parent;
+        }
+
+        // Fallback: .unityctl/plugins in CWD
+        return Path.Combine(Directory.GetCurrentDirectory(), ".unityctl", PluginDirName);
+    }
+
+    public static string GetUserPluginsDirectory()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".unityctl", PluginDirName);
+    }
+
+    private static List<LoadedPlugin> LoadPluginsFromDirectory(string pluginsDir, string source)
+    {
+        var plugins = new List<LoadedPlugin>();
+
+        if (!Directory.Exists(pluginsDir))
+            return plugins;
+
+        foreach (var dir in Directory.GetDirectories(pluginsDir))
+        {
+            var manifestPath = Path.Combine(dir, ManifestFileName);
+            if (!File.Exists(manifestPath))
+                continue;
+
+            try
+            {
+                var json = File.ReadAllText(manifestPath);
+                var manifest = JsonConvert.DeserializeObject<PluginManifest>(json);
+                if (manifest != null)
+                {
+                    plugins.Add(new LoadedPlugin
+                    {
+                        Manifest = manifest,
+                        Directory = dir,
+                        Source = source
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Warning: Failed to load plugin from {dir}: {ex.Message}");
+            }
+        }
+
+        return plugins;
+    }
+
+    /// <summary>
+    /// Generates a SKILL.md section from a plugin manifest.
+    /// </summary>
+    public static string GenerateSkillSection(LoadedPlugin plugin)
+    {
+        // Check for custom skill section file
+        if (plugin.Manifest.Skill != null)
+        {
+            var skillPath = Path.Combine(plugin.Directory, plugin.Manifest.Skill.File);
+            if (File.Exists(skillPath))
+                return File.ReadAllText(skillPath);
+        }
+
+        // Auto-generate from manifest
+        var lines = new List<string>();
+        lines.Add($"### Plugin: {plugin.Manifest.Name}");
+        if (!string.IsNullOrEmpty(plugin.Manifest.Description))
+            lines.Add($"\n{plugin.Manifest.Description}");
+        lines.Add("");
+
+        foreach (var cmd in plugin.Manifest.Commands)
+        {
+            var usage = $"unityctl {plugin.Manifest.Name} {cmd.Name}";
+
+            // Add arguments to usage
+            foreach (var arg in cmd.Arguments)
+            {
+                usage += arg.Required ? $" <{arg.Name}>" : $" [{arg.Name}]";
+            }
+
+            // Add options to usage
+            foreach (var opt in cmd.Options)
+            {
+                var optName = opt.Name.StartsWith('-') ? opt.Name : $"--{opt.Name}";
+                usage += opt.Type == "bool" ? $" [{optName}]" : $" [{optName} <value>]";
+            }
+
+            lines.Add($"- `{usage}`");
+            if (!string.IsNullOrEmpty(cmd.Description))
+                lines.Add($"  {cmd.Description}");
+        }
+
+        lines.Add("");
+        return string.Join("\n", lines);
+    }
+}
+
+public class LoadedPlugin
+{
+    public required PluginManifest Manifest { get; set; }
+    public required string Directory { get; set; }
+    public required string Source { get; set; }
+}

--- a/UnityCtl.Cli/PluginLoader.cs
+++ b/UnityCtl.Cli/PluginLoader.cs
@@ -70,6 +70,12 @@ public static class PluginLoader
 
         foreach (var cmdDef in plugin.Manifest.Commands)
         {
+            if (!string.Equals(cmdDef.Handler.Type, "script", StringComparison.OrdinalIgnoreCase))
+            {
+                Console.Error.WriteLine($"Warning: Plugin '{plugin.Manifest.Name}' command '{cmdDef.Name}' has unsupported handler type '{cmdDef.Handler.Type}' (expected 'script'), skipping.");
+                continue;
+            }
+
             var subCommand = new Command(cmdDef.Name, cmdDef.Description ?? cmdDef.Name);
 
             // Add arguments

--- a/UnityCtl.Cli/PluginLoader.cs
+++ b/UnityCtl.Cli/PluginLoader.cs
@@ -21,6 +21,19 @@ public static class PluginLoader
     public const string ManifestFileName = "plugin.json";
 
     /// <summary>
+    /// Builds the exclude-names set (built-in + script plugin names) used when discovering executable plugins.
+    /// Returns both the script plugins and the combined exclude set.
+    /// </summary>
+    public static (List<LoadedPlugin> ScriptPlugins, HashSet<string> ExcludeNames) DiscoverWithExclusions(ISet<string> builtInNames)
+    {
+        var scriptPlugins = DiscoverPlugins();
+        var excludeNames = new HashSet<string>(builtInNames, StringComparer.OrdinalIgnoreCase);
+        foreach (var sp in scriptPlugins)
+            excludeNames.Add(sp.Manifest.Name);
+        return (scriptPlugins, excludeNames);
+    }
+
+    /// <summary>
     /// Discovers all plugins from both project-level and user-level directories.
     /// Project-level plugins override user-level plugins with the same name.
     /// </summary>
@@ -30,11 +43,8 @@ public static class PluginLoader
 
         // User-level first (lower precedence)
         var userDir = GetUserPluginsDirectory();
-        if (userDir != null)
-        {
-            foreach (var plugin in LoadPluginsFromDirectory(userDir, "user"))
-                plugins[plugin.Manifest.Name] = plugin;
-        }
+        foreach (var plugin in LoadPluginsFromDirectory(userDir, "user"))
+            plugins[plugin.Manifest.Name] = plugin;
 
         // Project-level second (higher precedence, overwrites user-level)
         var projectDir = GetProjectPluginsDirectory();
@@ -124,11 +134,7 @@ public static class PluginLoader
 
         // Read the script file (validate path stays within plugin directory)
         var scriptPath = Path.GetFullPath(Path.Combine(pluginDir, handlerFile));
-        var resolvedPluginDir = Path.GetFullPath(pluginDir) + Path.DirectorySeparatorChar;
-        var pathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-        if (!scriptPath.StartsWith(resolvedPluginDir, pathComparison))
+        if (!IsPathWithin(pluginDir, handlerFile))
         {
             Console.Error.WriteLine($"Error: Plugin script path escapes plugin directory: {handlerFile}");
             context.ExitCode = 1;
@@ -193,6 +199,21 @@ public static class PluginLoader
         }
 
         ScriptCommands.DisplayScriptResult(context, response, json);
+    }
+
+    /// <summary>
+    /// Checks whether a file path resolves to a location within the given directory.
+    /// Used to prevent path-traversal attacks in plugin handler file references.
+    /// </summary>
+    public static bool IsPathWithin(string directory, string filePath)
+    {
+        var resolvedFile = Path.GetFullPath(Path.Combine(directory, filePath));
+        var resolvedDir = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return resolvedFile.StartsWith(resolvedDir, comparison);
     }
 
     /// <summary>
@@ -279,11 +300,7 @@ public static class PluginLoader
         if (plugin.Manifest.Skill != null)
         {
             var skillPath = Path.GetFullPath(Path.Combine(plugin.Directory, plugin.Manifest.Skill.File));
-            var resolvedDir = Path.GetFullPath(plugin.Directory) + Path.DirectorySeparatorChar;
-            var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? StringComparison.OrdinalIgnoreCase
-                : StringComparison.Ordinal;
-            if (skillPath.StartsWith(resolvedDir, comparison)
+            if (IsPathWithin(plugin.Directory, plugin.Manifest.Skill.File)
                 && File.Exists(skillPath))
                 return File.ReadAllText(skillPath);
         }

--- a/UnityCtl.Cli/PluginManifest.cs
+++ b/UnityCtl.Cli/PluginManifest.cs
@@ -1,0 +1,82 @@
+using System;
+using Newtonsoft.Json;
+
+namespace UnityCtl.Cli;
+
+/// <summary>
+/// Represents a plugin.json manifest file that declares CLI commands backed by C# scripts.
+/// </summary>
+public class PluginManifest
+{
+    [JsonProperty("name")]
+    public required string Name { get; set; }
+
+    [JsonProperty("version")]
+    public string? Version { get; set; }
+
+    [JsonProperty("description")]
+    public string? Description { get; set; }
+
+    [JsonProperty("commands")]
+    public PluginCommandDefinition[] Commands { get; set; } = Array.Empty<PluginCommandDefinition>();
+
+    [JsonProperty("skill")]
+    public PluginSkillSection? Skill { get; set; }
+}
+
+public class PluginCommandDefinition
+{
+    [JsonProperty("name")]
+    public required string Name { get; set; }
+
+    [JsonProperty("description")]
+    public string? Description { get; set; }
+
+    [JsonProperty("arguments")]
+    public PluginArgumentDefinition[] Arguments { get; set; } = Array.Empty<PluginArgumentDefinition>();
+
+    [JsonProperty("options")]
+    public PluginOptionDefinition[] Options { get; set; } = Array.Empty<PluginOptionDefinition>();
+
+    [JsonProperty("handler")]
+    public required PluginHandler Handler { get; set; }
+}
+
+public class PluginArgumentDefinition
+{
+    [JsonProperty("name")]
+    public required string Name { get; set; }
+
+    [JsonProperty("description")]
+    public string? Description { get; set; }
+
+    [JsonProperty("required")]
+    public bool Required { get; set; }
+}
+
+public class PluginOptionDefinition
+{
+    [JsonProperty("name")]
+    public required string Name { get; set; }
+
+    [JsonProperty("description")]
+    public string? Description { get; set; }
+
+    [JsonProperty("type")]
+    public string Type { get; set; } = "string";
+}
+
+public class PluginHandler
+{
+    [JsonProperty("type")]
+    public string Type { get; set; } = "script";
+
+    [JsonProperty("file")]
+    public required string File { get; set; }
+}
+
+public class PluginSkillSection
+{
+    [JsonProperty("file")]
+    public required string File { get; set; }
+}

--- a/UnityCtl.Cli/Program.cs
+++ b/UnityCtl.Cli/Program.cs
@@ -121,7 +121,8 @@ if (args.Length > 0)
             unmatchedCommand, passThrough,
             parseResult.GetValueForOption(projectOption),
             parseResult.GetValueForOption(agentIdOption),
-            parseResult.GetValueForOption(jsonOption));
+            parseResult.GetValueForOption(jsonOption),
+            parseResult.GetValueForOption(timeoutOption));
         if (exitCode.HasValue)
             return exitCode.Value;
     }

--- a/UnityCtl.Cli/Program.cs
+++ b/UnityCtl.Cli/Program.cs
@@ -68,7 +68,7 @@ rootCommand.AddCommand(PrefabCommand.CreateCommand());
 var registeredNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 foreach (var cmd in rootCommand.Children.OfType<Command>())
     registeredNames.Add(cmd.Name);
-PluginCommands.BuiltInCommandNames = registeredNames;
+PluginCommands.InitializeBuiltInCommandNames(registeredNames);
 
 try
 {

--- a/UnityCtl.Cli/Program.cs
+++ b/UnityCtl.Cli/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using System.Linq;
 using System.Threading.Tasks;
 using UnityCtl.Cli;
@@ -106,13 +107,24 @@ catch (Exception ex)
 // "Did you mean?" hints for common misses
 CommandHints.Register(rootCommand);
 
-// If the first arg doesn't match any registered command, try to run it as
+// If the first non-option arg doesn't match any registered command, try to run it as
 // "unityctl-<name>" on PATH (like git resolves "git foo" → "git-foo").
-if (args.Length > 0 && !registeredNames.Contains(args[0]) && !args[0].StartsWith("-"))
+// Use System.CommandLine's parser to extract global options so they're forwarded correctly.
+if (args.Length > 0)
 {
-    var exitCode = await ExecutablePluginLoader.TryExecuteByName(args[0], args.Skip(1).ToArray());
-    if (exitCode.HasValue)
-        return exitCode.Value;
+    var parseResult = rootCommand.Parse(args);
+    var unmatchedCommand = parseResult.UnmatchedTokens.FirstOrDefault();
+    if (unmatchedCommand != null && !unmatchedCommand.StartsWith("-"))
+    {
+        var passThrough = parseResult.UnmatchedTokens.Skip(1).ToArray();
+        var exitCode = await ExecutablePluginLoader.TryExecuteByName(
+            unmatchedCommand, passThrough,
+            parseResult.GetValueForOption(projectOption),
+            parseResult.GetValueForOption(agentIdOption),
+            parseResult.GetValueForOption(jsonOption));
+        if (exitCode.HasValue)
+            return exitCode.Value;
+    }
 }
 
 return await rootCommand.InvokeAsync(args);

--- a/UnityCtl.Cli/Program.cs
+++ b/UnityCtl.Cli/Program.cs
@@ -88,7 +88,8 @@ catch (Exception ex)
     Console.Error.WriteLine($"Warning: Failed to load plugins: {ex.Message}");
 }
 
-// Dynamically register executable plugins (lowest precedence)
+// Register executable plugins from plugin directories only (cheap scan).
+// PATH executables are resolved lazily at invocation time (git-style).
 try
 {
     var executablePlugins = ExecutablePluginLoader.DiscoverExecutablePlugins(registeredNames);
@@ -104,5 +105,14 @@ catch (Exception ex)
 
 // "Did you mean?" hints for common misses
 CommandHints.Register(rootCommand);
+
+// If the first arg doesn't match any registered command, try to run it as
+// "unityctl-<name>" on PATH (like git resolves "git foo" → "git-foo").
+if (args.Length > 0 && !registeredNames.Contains(args[0]) && !args[0].StartsWith("-"))
+{
+    var exitCode = await ExecutablePluginLoader.TryExecuteByName(args[0], args.Skip(1).ToArray());
+    if (exitCode.HasValue)
+        return exitCode.Value;
+}
 
 return await rootCommand.InvokeAsync(args);

--- a/UnityCtl.Cli/Program.cs
+++ b/UnityCtl.Cli/Program.cs
@@ -74,6 +74,11 @@ try
     var plugins = PluginLoader.DiscoverPlugins();
     foreach (var plugin in plugins)
     {
+        if (registeredNames.Contains(plugin.Manifest.Name))
+        {
+            Console.Error.WriteLine($"Warning: Plugin '{plugin.Manifest.Name}' conflicts with a built-in command and was skipped.");
+            continue;
+        }
         rootCommand.AddCommand(PluginLoader.CreateCommandFromPlugin(plugin));
         registeredNames.Add(plugin.Manifest.Name);
     }

--- a/UnityCtl.Cli/Program.cs
+++ b/UnityCtl.Cli/Program.cs
@@ -37,6 +37,7 @@ rootCommand.AddCommand(UpdateCommands.CreateCommand());
 rootCommand.AddCommand(ConfigCommands.CreateCommand());
 rootCommand.AddCommand(PackageCommands.CreateCommand());
 rootCommand.AddCommand(SkillCommands.CreateCommand());
+rootCommand.AddCommand(PluginCommands.CreateCommand());
 
 // Add subcommands - Status & Logs
 rootCommand.AddCommand(StatusCommand.CreateCommand());
@@ -59,6 +60,20 @@ rootCommand.AddCommand(RecordCommands.CreateCommand());
 rootCommand.AddCommand(ScriptCommands.CreateCommand());
 rootCommand.AddCommand(SnapshotCommand.CreateCommand());
 rootCommand.AddCommand(PrefabCommand.CreateCommand());
+
+// Dynamically register plugin commands
+try
+{
+    var plugins = PluginLoader.DiscoverPlugins();
+    foreach (var plugin in plugins)
+    {
+        rootCommand.AddCommand(PluginLoader.CreateCommandFromPlugin(plugin));
+    }
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Warning: Failed to load plugins: {ex.Message}");
+}
 
 // "Did you mean?" hints for common misses
 CommandHints.Register(rootCommand);

--- a/UnityCtl.Cli/Program.cs
+++ b/UnityCtl.Cli/Program.cs
@@ -63,10 +63,11 @@ rootCommand.AddCommand(ScriptCommands.CreateCommand());
 rootCommand.AddCommand(SnapshotCommand.CreateCommand());
 rootCommand.AddCommand(PrefabCommand.CreateCommand());
 
-// Dynamically register plugin commands
+// Derive built-in command names dynamically from registered commands
 var registeredNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 foreach (var cmd in rootCommand.Children.OfType<Command>())
     registeredNames.Add(cmd.Name);
+PluginCommands.BuiltInCommandNames = registeredNames;
 
 try
 {

--- a/UnityCtl.Cli/Program.cs
+++ b/UnityCtl.Cli/Program.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
+using System.Linq;
 using System.Threading.Tasks;
 using UnityCtl.Cli;
 
@@ -62,17 +64,36 @@ rootCommand.AddCommand(SnapshotCommand.CreateCommand());
 rootCommand.AddCommand(PrefabCommand.CreateCommand());
 
 // Dynamically register plugin commands
+var registeredNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+foreach (var cmd in rootCommand.Children.OfType<Command>())
+    registeredNames.Add(cmd.Name);
+
 try
 {
     var plugins = PluginLoader.DiscoverPlugins();
     foreach (var plugin in plugins)
     {
         rootCommand.AddCommand(PluginLoader.CreateCommandFromPlugin(plugin));
+        registeredNames.Add(plugin.Manifest.Name);
     }
 }
 catch (Exception ex)
 {
     Console.Error.WriteLine($"Warning: Failed to load plugins: {ex.Message}");
+}
+
+// Dynamically register executable plugins (lowest precedence)
+try
+{
+    var executablePlugins = ExecutablePluginLoader.DiscoverExecutablePlugins(registeredNames);
+    foreach (var plugin in executablePlugins)
+    {
+        rootCommand.AddCommand(ExecutablePluginLoader.CreateCommandFromExecutablePlugin(plugin));
+    }
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Warning: Failed to load executable plugins: {ex.Message}");
 }
 
 // "Did you mean?" hints for common misses

--- a/UnityCtl.Cli/Resources/SKILL.md
+++ b/UnityCtl.Cli/Resources/SKILL.md
@@ -174,12 +174,3 @@ Run `unityctl status` first to diagnose issues.
 | Command timed out | A native dialog may be blocking Unity: `unityctl dialog list` |
 | Progress bar stuck | Check with `unityctl dialog list`, wait or dismiss |
 | Editor not found | Use `--unity-path` to specify Unity executable |
-
-## Plugin Commands
-
-### Plugin: sample-script
-
-Sample script plugin demonstrating the plugin system
-
-- `unityctl sample-script hello [name] [--loud]`
-  Say hello from Unity

--- a/UnityCtl.Cli/Resources/SKILL.plugins.md
+++ b/UnityCtl.Cli/Resources/SKILL.plugins.md
@@ -1,0 +1,154 @@
+---
+name: unityctl-plugins
+description: Create unityctl plugins. Use when the user wants to create, scaffold, or write a unityctl plugin (script or executable).
+---
+
+# Creating unityctl Plugins
+
+There are two plugin types: **script** (C# running inside Unity) and **executable** (any program on disk).
+
+## Script Plugins
+
+Run C# inside the Unity Editor via the `script.execute` RPC. Best for commands that need Unity APIs.
+
+### Quick start
+
+```bash
+unityctl plugin create my-tool   # scaffolds .unityctl/plugins/my-tool/
+```
+
+### Structure
+
+```
+.unityctl/plugins/my-tool/
+  plugin.json    # manifest
+  hello.cs       # handler script
+```
+
+### plugin.json
+
+```json
+{
+  "name": "my-tool",
+  "version": "1.0.0",
+  "description": "My custom tool",
+  "commands": [
+    {
+      "name": "stats",
+      "description": "Show scene stats",
+      "arguments": [
+        { "name": "scene", "description": "Scene name", "required": false }
+      ],
+      "options": [
+        { "name": "verbose", "type": "bool", "description": "Show details" },
+        { "name": "format", "type": "string", "description": "Output format" }
+      ],
+      "handler": { "type": "script", "file": "stats.cs" }
+    }
+  ],
+  "skill": { "file": "SKILL.md" }
+}
+```
+
+### Handler script
+
+Must define `public class Script` with `public static object Main(string[] args)`. Arguments and options are passed as the `args` array.
+
+```csharp
+using UnityEngine;
+using UnityEditor;
+
+public class Script
+{
+    public static object Main(string[] args)
+    {
+        var count = Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None).Length;
+        return $"Scene has {count} GameObjects";
+    }
+}
+```
+
+The return value is sent back as the command output. The script runs on Unity's main thread and has access to all Unity and UnityEditor APIs.
+
+### Custom skill documentation
+
+Add a `"skill": { "file": "SKILL.md" }` entry to plugin.json and create the markdown file. It will be included in the composed SKILL.md when running `unityctl skill rebuild`. Without it, documentation is auto-generated from the manifest.
+
+### Location
+
+| Level | Directory | Precedence |
+|-------|-----------|------------|
+| Project | `.unityctl/plugins/` | Higher |
+| User | `~/.unityctl/plugins/` | Lower |
+
+Use `--global` / `-g` with `plugin create` to scaffold at user level.
+
+Plugin names must be lowercase alphanumeric with hyphens (e.g. `my-tool`, `scene-stats`). Must start and end with a letter or digit.
+
+## Executable Plugins
+
+Any executable named `unityctl-<name>` becomes available as `unityctl <name>`. Best for workflows outside Unity: build pipelines, CI scripts, multi-step orchestration.
+
+### How it works
+
+Place an executable (shell script, Python, Go binary, .bat/.cmd/.ps1 on Windows) named `unityctl-<name>` in `.unityctl/plugins/` or on PATH. All arguments after the command name are passed through.
+
+Executables in plugin directories are registered at startup (appear in `--help`). Executables on PATH are resolved lazily when invoked — like `git` resolving `git foo` → `git-foo`.
+
+```bash
+unityctl smoke 30          # finds and runs unityctl-smoke with arg "30"
+unityctl deploy --staging  # finds and runs unityctl-deploy with arg "--staging"
+```
+
+### Environment variables
+
+The CLI sets these before launching the executable:
+
+| Variable | Description |
+|----------|-------------|
+| `UNITYCTL_PROJECT_PATH` | Resolved Unity project root |
+| `UNITYCTL_BRIDGE_PORT` | Bridge HTTP port |
+| `UNITYCTL_BRIDGE_URL` | Full bridge URL (e.g. `http://localhost:62908`) |
+| `UNITYCTL_AGENT_ID` | Agent ID if `--agent-id` was passed |
+| `UNITYCTL_JSON` | `"1"` if `--json` was passed |
+
+### Example
+
+```bash
+#!/usr/bin/env bash
+# Save as: unityctl-smoke (chmod +x)
+unityctl logs clear
+unityctl play enter
+sleep "${1:-10}"
+unityctl screenshot capture --json > /tmp/smoke.json
+ERRORS=$(unityctl logs -n 1000 --json | jq '[.entries[] | select(.level == "Error")] | length')
+unityctl play exit
+[ "$ERRORS" -eq 0 ] && echo "PASS" || { echo "FAIL: $ERRORS error(s)"; exit 1; }
+```
+
+### Companion skill file
+
+Place `unityctl-<name>.skill.md` next to the executable to provide custom documentation for SKILL.md composition. Without it, a minimal section is auto-generated.
+
+### Platform notes
+
+- **Windows**: matches `.exe`, `.cmd`, `.bat`, `.ps1` extensions
+- **Unix**: matches any file with execute permission; extensions are stripped from the command name (`unityctl-foo.sh` becomes `unityctl foo`)
+
+## Precedence
+
+built-in command > script plugin > executable plugin. A plugin cannot shadow a built-in command.
+
+## After changes
+
+Run `unityctl skill rebuild` to update the composed SKILL.md with plugin documentation.
+
+## Management commands
+
+```bash
+unityctl plugin list              # list all plugins (script + executable)
+unityctl plugin create <name>     # scaffold a script plugin
+unityctl plugin create <name> -g  # scaffold at user level (~/.unityctl/plugins/)
+unityctl plugin remove <name>     # remove a script plugin (prompts for confirmation)
+unityctl plugin remove <name> -f  # remove without confirmation
+```

--- a/UnityCtl.Cli/Resources/SKILL.plugins.md
+++ b/UnityCtl.Cli/Resources/SKILL.plugins.md
@@ -149,6 +149,5 @@ Run `unityctl skill rebuild` to update the composed SKILL.md with plugin documen
 unityctl plugin list              # list all plugins (script + executable)
 unityctl plugin create <name>     # scaffold a script plugin
 unityctl plugin create <name> -g  # scaffold at user level (~/.unityctl/plugins/)
-unityctl plugin remove <name>     # remove a script plugin (prompts for confirmation)
-unityctl plugin remove <name> -f  # remove without confirmation
+unityctl plugin remove <name>     # remove a script plugin
 ```

--- a/UnityCtl.Cli/ScriptCommands.cs
+++ b/UnityCtl.Cli/ScriptCommands.cs
@@ -305,7 +305,7 @@ public static class ScriptCommands
         return sb.ToString();
     }
 
-    private static void DisplayScriptResult(InvocationContext context, ResponseMessage response, bool json, bool isEval, string? generatedCode = null)
+    internal static void DisplayScriptResult(InvocationContext context, ResponseMessage response, bool json, bool isEval = false, string? generatedCode = null)
     {
         var result = JsonConvert.DeserializeObject<ScriptExecuteResult>(
             JsonConvert.SerializeObject(response.Result, JsonHelper.Settings),

--- a/UnityCtl.Cli/SkillCommands.cs
+++ b/UnityCtl.Cli/SkillCommands.cs
@@ -152,20 +152,14 @@ public static class SkillCommands
 
     /// <summary>
     /// Composes the final SKILL.md from: base embedded skill + plugin sections + user extra.
+    /// The base skill lives in UnityCtl.Cli/Resources/ and is never overwritten by compose output.
     /// </summary>
     public static string? ComposeSkillContent()
     {
-        // 1. Base skill content
+        // 1. Base skill content (from embedded resource in Resources/SKILL.md)
         var baseContent = GetEmbeddedSkillContent();
         if (baseContent == null)
             return null;
-
-        // Strip any previously composed plugin/extra sections to make rebuild idempotent.
-        // The embedded resource or dev fallback may contain a prior compose result.
-        var pluginMarker = "\n## Plugin Commands";
-        var markerIndex = baseContent.IndexOf(pluginMarker, StringComparison.Ordinal);
-        if (markerIndex >= 0)
-            baseContent = baseContent.Substring(0, markerIndex);
 
         // 2. Plugin sections (script + executable)
         var plugins = PluginLoader.DiscoverPlugins();
@@ -307,12 +301,18 @@ public static class SkillCommands
         using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null)
         {
-            // Fallback: try to find SKILL.md in development environment
+            // Fallback: try to find file in Resources/ during development.
+            // The resource logical name is like "UnityCtl.Cli.Resources.SKILL.md"
+            // — extract the filename portion after the last "Resources." prefix.
+            var prefix = "UnityCtl.Cli.Resources.";
+            var fileName = resourceName.StartsWith(prefix)
+                ? resourceName.Substring(prefix.Length)
+                : "SKILL.md";
+
             var possiblePaths = new[]
             {
-                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".claude", "skills", folderName, "SKILL.md"),
-                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".claude", "skills", folderName, "SKILL.md"),
-                Path.Combine(Directory.GetCurrentDirectory(), ".claude", "skills", folderName, "SKILL.md")
+                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "UnityCtl.Cli", "Resources", fileName),
+                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "UnityCtl.Cli", "Resources", fileName),
             };
 
             foreach (var path in possiblePaths)

--- a/UnityCtl.Cli/SkillCommands.cs
+++ b/UnityCtl.Cli/SkillCommands.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
@@ -15,11 +16,14 @@ public static class SkillCommands
     private const string SkillFileName = "SKILL.md";
     private const string EmbeddedResourceName = "UnityCtl.Cli.Resources.SKILL.md";
 
+    private const string SkillExtraFileName = "skill-extra.md";
+
     public static Command CreateCommand()
     {
         var skillCommand = new Command("skill", "Claude Code skill management");
 
         skillCommand.AddCommand(CreateAddCommand());
+        skillCommand.AddCommand(CreateRebuildCommand());
         skillCommand.AddCommand(CreateRemoveCommand());
         skillCommand.AddCommand(CreateStatusCommand());
 
@@ -62,6 +66,150 @@ public static class SkillCommands
         });
 
         return addCommand;
+    }
+
+    private static Command CreateRebuildCommand()
+    {
+        var rebuildCommand = new Command("rebuild", "Rebuild composed SKILL.md from base + plugins + user extra");
+
+        var globalOption = new Option<bool>(
+            "--global",
+            "Rebuild global ~/.claude/skills/ instead of local .claude/skills/"
+        );
+        globalOption.AddAlias("-g");
+
+        var claudeDirOption = new Option<string?>(
+            "--claude-dir",
+            "Custom Claude directory (default: ~/.claude or ./.claude)"
+        );
+
+        rebuildCommand.AddOption(globalOption);
+        rebuildCommand.AddOption(claudeDirOption);
+
+        rebuildCommand.SetHandler(async (InvocationContext context) =>
+        {
+            var global = context.ParseResult.GetValueForOption(globalOption);
+            var claudeDir = context.ParseResult.GetValueForOption(claudeDirOption);
+            var json = ContextHelper.GetJson(context);
+
+            var skillsDir = GetSkillsDirectory(global, claudeDir);
+            var skillPath = Path.Combine(skillsDir, SkillFolderName, SkillFileName);
+
+            var content = ComposeSkillContent();
+            if (content == null)
+            {
+                if (json)
+                {
+                    Console.WriteLine(JsonHelper.Serialize(new
+                    {
+                        success = false,
+                        error = "base_skill_not_found",
+                        message = "Could not find embedded SKILL.md resource"
+                    }));
+                }
+                else
+                {
+                    Console.Error.WriteLine("Error: Could not find base skill content.");
+                }
+                context.ExitCode = 1;
+                return;
+            }
+
+            var dir = Path.GetDirectoryName(skillPath);
+            if (dir != null) Directory.CreateDirectory(dir);
+
+            await File.WriteAllTextAsync(skillPath, content);
+
+            if (json)
+            {
+                Console.WriteLine(JsonHelper.Serialize(new
+                {
+                    success = true,
+                    path = skillPath,
+                    global,
+                    composed = true
+                }));
+            }
+            else
+            {
+                Console.WriteLine($"Rebuilt skill at: {skillPath}");
+                Console.WriteLine("Restart Claude Code to load the updated skill.");
+            }
+        });
+
+        return rebuildCommand;
+    }
+
+    /// <summary>
+    /// Composes the final SKILL.md from: base embedded skill + plugin sections + user extra.
+    /// </summary>
+    public static string? ComposeSkillContent()
+    {
+        // 1. Base skill content
+        var baseContent = GetEmbeddedSkillContent();
+        if (baseContent == null)
+            return null;
+
+        // 2. Plugin sections
+        var plugins = PluginLoader.DiscoverPlugins();
+        string? pluginSections = null;
+        if (plugins.Count > 0)
+        {
+            var sections = new List<string>();
+            sections.Add("## Plugin Commands");
+            sections.Add("");
+            foreach (var plugin in plugins)
+            {
+                sections.Add(PluginLoader.GenerateSkillSection(plugin));
+            }
+            pluginSections = string.Join("\n", sections);
+        }
+
+        // 3. User extra (.unityctl/skill-extra.md)
+        string? userExtra = null;
+        var extraPath = FindSkillExtraFile();
+        if (extraPath != null && File.Exists(extraPath))
+        {
+            userExtra = File.ReadAllText(extraPath);
+        }
+
+        // Compose
+        if (pluginSections == null && userExtra == null)
+            return baseContent;
+
+        var composed = baseContent.TrimEnd();
+
+        if (pluginSections != null)
+        {
+            composed += "\n\n" + pluginSections.TrimEnd();
+        }
+
+        if (userExtra != null)
+        {
+            composed += "\n\n" + userExtra.TrimEnd();
+        }
+
+        return composed + "\n";
+    }
+
+    private static string? FindSkillExtraFile()
+    {
+        // Walk up from CWD looking for .unityctl/skill-extra.md
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current != null)
+        {
+            var extraPath = Path.Combine(current.FullName, ".unityctl", SkillExtraFileName);
+            if (File.Exists(extraPath))
+                return extraPath;
+
+            // Stop at .unityctl directory boundary
+            var unityctlDir = Path.Combine(current.FullName, ".unityctl");
+            if (Directory.Exists(unityctlDir))
+                return extraPath; // Return the path even if file doesn't exist (checked by caller)
+
+            current = current.Parent;
+        }
+        return null;
     }
 
     private static Command CreateRemoveCommand()
@@ -168,7 +316,7 @@ public static class SkillCommands
     /// </summary>
     public static async Task<bool> UpdateSkillFileAsync(string skillPath)
     {
-        var content = GetEmbeddedSkillContent();
+        var content = ComposeSkillContent();
         if (content == null) return false;
 
         var dir = Path.GetDirectoryName(skillPath);
@@ -209,8 +357,8 @@ public static class SkillCommands
             }
         }
 
-        // Get skill content
-        var skillContent = GetEmbeddedSkillContent();
+        // Get composed skill content (base + plugins + user extra)
+        var skillContent = ComposeSkillContent();
         if (skillContent == null)
         {
             if (json)

--- a/UnityCtl.Cli/SkillCommands.cs
+++ b/UnityCtl.Cli/SkillCommands.cs
@@ -150,10 +150,21 @@ public static class SkillCommands
         if (baseContent == null)
             return null;
 
-        // 2. Plugin sections
+        // Strip any previously composed plugin/extra sections to make rebuild idempotent.
+        // The embedded resource or dev fallback may contain a prior compose result.
+        var pluginMarker = "\n## Plugin Commands";
+        var markerIndex = baseContent.IndexOf(pluginMarker, StringComparison.Ordinal);
+        if (markerIndex >= 0)
+            baseContent = baseContent.Substring(0, markerIndex);
+
+        // 2. Plugin sections (script + executable)
         var plugins = PluginLoader.DiscoverPlugins();
+        var excludeNames = new HashSet<string>(PluginCommands.BuiltInCommandNames, StringComparer.OrdinalIgnoreCase);
+        foreach (var sp in plugins)
+            excludeNames.Add(sp.Manifest.Name);
+        var executablePlugins = ExecutablePluginLoader.DiscoverExecutablePlugins(excludeNames);
         string? pluginSections = null;
-        if (plugins.Count > 0)
+        if (plugins.Count > 0 || executablePlugins.Count > 0)
         {
             var sections = new List<string>();
             sections.Add("## Plugin Commands");
@@ -161,6 +172,12 @@ public static class SkillCommands
             foreach (var plugin in plugins)
             {
                 sections.Add(PluginLoader.GenerateSkillSection(plugin));
+            }
+            foreach (var execPlugin in executablePlugins)
+            {
+                var section = ExecutablePluginLoader.GetSkillSection(execPlugin);
+                if (section != null)
+                    sections.Add(section);
             }
             pluginSections = string.Join("\n", sections);
         }

--- a/UnityCtl.Cli/SkillCommands.cs
+++ b/UnityCtl.Cli/SkillCommands.cs
@@ -162,10 +162,7 @@ public static class SkillCommands
             return null;
 
         // 2. Plugin sections (script + executable)
-        var plugins = PluginLoader.DiscoverPlugins();
-        var excludeNames = new HashSet<string>(PluginCommands.BuiltInCommandNames, StringComparer.OrdinalIgnoreCase);
-        foreach (var sp in plugins)
-            excludeNames.Add(sp.Manifest.Name);
+        var (plugins, excludeNames) = PluginLoader.DiscoverWithExclusions(PluginCommands.BuiltInCommandNames);
         var executablePlugins = ExecutablePluginLoader.DiscoverExecutablePlugins(excludeNames);
         string? pluginSections = null;
         if (plugins.Count > 0 || executablePlugins.Count > 0)

--- a/UnityCtl.Cli/SkillCommands.cs
+++ b/UnityCtl.Cli/SkillCommands.cs
@@ -243,7 +243,8 @@ public static class SkillCommands
             var claudeDir = context.ParseResult.GetValueForOption(claudeDirOption);
             var json = ContextHelper.GetJson(context);
 
-            RemoveSkill(global, claudeDir, json);
+            if (!RemoveSkill(global, claudeDir, json))
+                context.ExitCode = 1;
         });
 
         return removeCommand;
@@ -288,10 +289,10 @@ public static class SkillCommands
 
     private static string? GetEmbeddedSkillContent()
     {
-        return GetEmbeddedResourceContent(EmbeddedResourceName, SkillFolderName);
+        return GetEmbeddedResourceContent(EmbeddedResourceName);
     }
 
-    private static string? GetEmbeddedResourceContent(string resourceName, string folderName)
+    private static string? GetEmbeddedResourceContent(string resourceName)
     {
         var assembly = Assembly.GetExecutingAssembly();
 
@@ -445,7 +446,7 @@ public static class SkillCommands
         return true;
     }
 
-    private static void RemoveSkill(bool global, string? claudeDir, bool json)
+    private static bool RemoveSkill(bool global, string? claudeDir, bool json)
     {
         var skillsDir = GetSkillsDirectory(global, claudeDir);
         var skillFolderPath = Path.Combine(skillsDir, SkillFolderName);
@@ -466,7 +467,7 @@ public static class SkillCommands
             {
                 Console.Error.WriteLine($"Skill not found at: {skillPath}");
             }
-            return;
+            return false;
         }
 
         File.Delete(skillPath);
@@ -500,6 +501,7 @@ public static class SkillCommands
         {
             Console.WriteLine($"Removed skills from: {skillsDir}");
         }
+        return true;
     }
 
     private static void CleanupEmptyDirectory(string path)
@@ -522,7 +524,7 @@ public static class SkillCommands
             if (onlyIfExists && !File.Exists(filePath))
                 continue;
 
-            var content = GetEmbeddedResourceContent(resource, folder);
+            var content = GetEmbeddedResourceContent(resource);
             if (content == null)
                 continue;
 

--- a/UnityCtl.Cli/SkillCommands.cs
+++ b/UnityCtl.Cli/SkillCommands.cs
@@ -103,46 +103,25 @@ public static class SkillCommands
             var json = ContextHelper.GetJson(context);
 
             var skillsDir = GetSkillsDirectory(global, claudeDir);
-            var skillPath = Path.Combine(skillsDir, SkillFolderName, SkillFileName);
-
-            var content = ComposeSkillContent();
-            if (content == null)
+            if (!await WriteComposedSkillAsync(skillsDir, json))
             {
-                if (json)
-                {
-                    Console.WriteLine(JsonHelper.Serialize(new
-                    {
-                        success = false,
-                        error = "base_skill_not_found",
-                        message = "Could not find embedded SKILL.md resource"
-                    }));
-                }
-                else
-                {
-                    Console.Error.WriteLine("Error: Could not find base skill content.");
-                }
                 context.ExitCode = 1;
                 return;
             }
-
-            var dir = Path.GetDirectoryName(skillPath);
-            if (dir != null) Directory.CreateDirectory(dir);
-
-            await File.WriteAllTextAsync(skillPath, content);
 
             if (json)
             {
                 Console.WriteLine(JsonHelper.Serialize(new
                 {
                     success = true,
-                    path = skillPath,
+                    path = Path.Combine(skillsDir, SkillFolderName, SkillFileName),
                     global,
                     composed = true
                 }));
             }
             else
             {
-                Console.WriteLine($"Rebuilt skill at: {skillPath}");
+                Console.WriteLine($"Rebuilt skill at: {Path.Combine(skillsDir, SkillFolderName, SkillFileName)}");
                 Console.WriteLine("Restart Claude Code to load the updated skill.");
             }
         });
@@ -299,9 +278,9 @@ public static class SkillCommands
         using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null)
         {
-            // Fallback: try to find file in Resources/ during development.
-            // The resource logical name is like "UnityCtl.Cli.Resources.SKILL.md"
-            // — extract the filename portion after the last "Resources." prefix.
+#if DEBUG
+            // Fallback: try to find file in Resources/ during development when the
+            // embedded resource may not be available (e.g. running via `dotnet run`).
             var prefix = "UnityCtl.Cli.Resources.";
             var fileName = resourceName.StartsWith(prefix)
                 ? resourceName.Substring(prefix.Length)
@@ -317,11 +296,9 @@ public static class SkillCommands
             {
                 var fullPath = Path.GetFullPath(path);
                 if (File.Exists(fullPath))
-                {
                     return File.ReadAllText(fullPath);
-                }
             }
-
+#endif
             return null;
         }
 
@@ -357,8 +334,7 @@ public static class SkillCommands
     public static async Task<bool> AddSkillAsync(bool global, string? claudeDir, bool force, bool json)
     {
         var skillsDir = GetSkillsDirectory(global, claudeDir);
-        var skillFolderPath = Path.Combine(skillsDir, SkillFolderName);
-        var skillPath = Path.Combine(skillFolderPath, SkillFileName);
+        var skillPath = Path.Combine(skillsDir, SkillFolderName, SkillFileName);
 
         // Check if skill already exists
         if (File.Exists(skillPath) && !force)
@@ -386,32 +362,8 @@ public static class SkillCommands
             }
         }
 
-        // Get composed skill content (base + plugins + user extra)
-        var skillContent = ComposeSkillContent();
-        if (skillContent == null)
-        {
-            if (json)
-            {
-                Console.WriteLine(JsonHelper.Serialize(new
-                {
-                    success = false,
-                    error = "skill_not_found",
-                    message = "Could not find embedded SKILL.md resource"
-                }));
-            }
-            else
-            {
-                Console.Error.WriteLine("Error: Could not find skill file.");
-                Console.Error.WriteLine("The SKILL.md resource may not be embedded in this build.");
-            }
+        if (!await WriteComposedSkillAsync(skillsDir, json))
             return false;
-        }
-
-        // Create directory if needed
-        Directory.CreateDirectory(skillFolderPath);
-
-        // Write skill file
-        await File.WriteAllTextAsync(skillPath, skillContent);
 
         // Install additional skills
         await InstallAdditionalSkillsAsync(skillsDir, onlyIfExists: false);
@@ -443,6 +395,38 @@ public static class SkillCommands
             Console.WriteLine("Restart Claude Code to load the new skills.");
         }
 
+        return true;
+    }
+
+    /// <summary>
+    /// Composes the skill content and writes it to the main skill file in the given skills directory.
+    /// Returns false and prints an error if the base skill resource is missing.
+    /// </summary>
+    private static async Task<bool> WriteComposedSkillAsync(string skillsDir, bool json)
+    {
+        var content = ComposeSkillContent();
+        if (content == null)
+        {
+            if (json)
+            {
+                Console.WriteLine(JsonHelper.Serialize(new
+                {
+                    success = false,
+                    error = "skill_not_found",
+                    message = "Could not find embedded SKILL.md resource"
+                }));
+            }
+            else
+            {
+                Console.Error.WriteLine("Error: Could not find skill file.");
+                Console.Error.WriteLine("The SKILL.md resource may not be embedded in this build.");
+            }
+            return false;
+        }
+
+        var skillFolderPath = Path.Combine(skillsDir, SkillFolderName);
+        Directory.CreateDirectory(skillFolderPath);
+        await File.WriteAllTextAsync(Path.Combine(skillFolderPath, SkillFileName), content);
         return true;
     }
 

--- a/UnityCtl.Cli/SkillCommands.cs
+++ b/UnityCtl.Cli/SkillCommands.cs
@@ -220,22 +220,11 @@ public static class SkillCommands
 
     private static string? FindSkillExtraFile()
     {
-        // Walk up from CWD looking for .unityctl/skill-extra.md
-        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
-        while (current != null)
-        {
-            var extraPath = Path.Combine(current.FullName, ".unityctl", SkillExtraFileName);
-            if (File.Exists(extraPath))
-                return extraPath;
+        var dotUnityctl = PluginLoader.FindDotUnityctlDirectory();
+        if (dotUnityctl == null) return null;
 
-            // Stop at .unityctl directory boundary
-            var unityctlDir = Path.Combine(current.FullName, ".unityctl");
-            if (Directory.Exists(unityctlDir))
-                return extraPath; // Return the path even if file doesn't exist (checked by caller)
-
-            current = current.Parent;
-        }
-        return null;
+        var extraPath = Path.Combine(dotUnityctl, SkillExtraFileName);
+        return File.Exists(extraPath) ? extraPath : null;
     }
 
     private static Command CreateRemoveCommand()

--- a/UnityCtl.Cli/SkillCommands.cs
+++ b/UnityCtl.Cli/SkillCommands.cs
@@ -71,7 +71,8 @@ public static class SkillCommands
             var force = context.ParseResult.GetValueForOption(forceOption);
             var json = ContextHelper.GetJson(context);
 
-            await AddSkillAsync(global, claudeDir, force, json);
+            if (!await AddSkillAsync(global, claudeDir, force, json))
+                context.ExitCode = 1;
         });
 
         return addCommand;
@@ -355,7 +356,7 @@ public static class SkillCommands
         return true;
     }
 
-    public static async Task AddSkillAsync(bool global, string? claudeDir, bool force, bool json)
+    public static async Task<bool> AddSkillAsync(bool global, string? claudeDir, bool force, bool json)
     {
         var skillsDir = GetSkillsDirectory(global, claudeDir);
         var skillFolderPath = Path.Combine(skillsDir, SkillFolderName);
@@ -372,6 +373,7 @@ public static class SkillCommands
                     error = "already_exists",
                     path = skillPath
                 }));
+                return false;
             }
             else
             {
@@ -381,7 +383,7 @@ public static class SkillCommands
                 if (response != "y" && response != "yes")
                 {
                     Console.WriteLine("Aborted.");
-                    return;
+                    return false;
                 }
             }
         }
@@ -404,7 +406,7 @@ public static class SkillCommands
                 Console.Error.WriteLine("Error: Could not find skill file.");
                 Console.Error.WriteLine("The SKILL.md resource may not be embedded in this build.");
             }
-            return;
+            return false;
         }
 
         // Create directory if needed
@@ -442,6 +444,8 @@ public static class SkillCommands
             Console.WriteLine();
             Console.WriteLine("Restart Claude Code to load the new skills.");
         }
+
+        return true;
     }
 
     private static void RemoveSkill(bool global, string? claudeDir, bool json)

--- a/UnityCtl.Cli/SkillCommands.cs
+++ b/UnityCtl.Cli/SkillCommands.cs
@@ -18,6 +18,15 @@ public static class SkillCommands
 
     private const string SkillExtraFileName = "skill-extra.md";
 
+    /// <summary>
+    /// Additional skills that are installed/updated alongside the main unity-editor skill.
+    /// Each entry is (folderName, embeddedResourceName).
+    /// </summary>
+    private static readonly (string Folder, string Resource)[] AdditionalSkills =
+    [
+        ("unityctl-plugins", "UnityCtl.Cli.Resources.SKILL.plugins.md")
+    ];
+
     public static Command CreateCommand()
     {
         var skillCommand = new Command("skill", "Claude Code skill management");
@@ -298,17 +307,22 @@ public static class SkillCommands
 
     private static string? GetEmbeddedSkillContent()
     {
+        return GetEmbeddedResourceContent(EmbeddedResourceName, SkillFolderName);
+    }
+
+    private static string? GetEmbeddedResourceContent(string resourceName, string folderName)
+    {
         var assembly = Assembly.GetExecutingAssembly();
 
-        using var stream = assembly.GetManifestResourceStream(EmbeddedResourceName);
+        using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null)
         {
             // Fallback: try to find SKILL.md in development environment
             var possiblePaths = new[]
             {
-                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".claude", "skills", "unity-editor", "SKILL.md"),
-                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".claude", "skills", "unity-editor", "SKILL.md"),
-                Path.Combine(Directory.GetCurrentDirectory(), ".claude", "skills", "unity-editor", "SKILL.md")
+                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".claude", "skills", folderName, "SKILL.md"),
+                Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".claude", "skills", folderName, "SKILL.md"),
+                Path.Combine(Directory.GetCurrentDirectory(), ".claude", "skills", folderName, "SKILL.md")
             };
 
             foreach (var path in possiblePaths)
@@ -329,6 +343,7 @@ public static class SkillCommands
 
     /// <summary>
     /// Updates the skill file at the given path with the latest embedded content.
+    /// Also updates any additional skills installed in the same skills directory.
     /// Returns true if successful, false if embedded content was not found.
     /// </summary>
     public static async Task<bool> UpdateSkillFileAsync(string skillPath)
@@ -340,6 +355,14 @@ public static class SkillCommands
         if (dir != null) Directory.CreateDirectory(dir);
 
         await File.WriteAllTextAsync(skillPath, content);
+
+        // Update additional skills if they exist alongside the main skill
+        var skillsDir = Path.GetDirectoryName(dir); // up from unity-editor/ to skills/
+        if (skillsDir != null)
+        {
+            await InstallAdditionalSkillsAsync(skillsDir, onlyIfExists: true);
+        }
+
         return true;
     }
 
@@ -401,6 +424,9 @@ public static class SkillCommands
         // Write skill file
         await File.WriteAllTextAsync(skillPath, skillContent);
 
+        // Install additional skills
+        await InstallAdditionalSkillsAsync(skillsDir, onlyIfExists: false);
+
         if (json)
         {
             Console.WriteLine(JsonHelper.Serialize(new
@@ -413,19 +439,19 @@ public static class SkillCommands
         }
         else
         {
-            Console.WriteLine($"Installed Claude Code skill to: {skillPath}");
+            Console.WriteLine($"Installed Claude Code skills to: {skillsDir}");
             Console.WriteLine();
             if (global)
             {
-                Console.WriteLine("The skill is now available globally for all projects.");
+                Console.WriteLine("The skills are now available globally for all projects.");
             }
             else
             {
-                Console.WriteLine("The skill is now available for this project.");
+                Console.WriteLine("The skills are now available for this project.");
                 Console.WriteLine("Use --global to install for all projects.");
             }
             Console.WriteLine();
-            Console.WriteLine("Restart Claude Code to load the new skill.");
+            Console.WriteLine("Restart Claude Code to load the new skills.");
         }
     }
 
@@ -455,17 +481,21 @@ public static class SkillCommands
 
         File.Delete(skillPath);
 
+        // Remove additional skills
+        foreach (var (folder, _) in AdditionalSkills)
+        {
+            var additionalPath = Path.Combine(skillsDir, folder, SkillFileName);
+            if (File.Exists(additionalPath))
+                File.Delete(additionalPath);
+        }
+
         // Try to clean up empty directories
         try
         {
-            if (Directory.Exists(skillFolderPath) && !Directory.EnumerateFileSystemEntries(skillFolderPath).Any())
-            {
-                Directory.Delete(skillFolderPath);
-            }
-            if (Directory.Exists(skillsDir) && !Directory.EnumerateFileSystemEntries(skillsDir).Any())
-            {
-                Directory.Delete(skillsDir);
-            }
+            CleanupEmptyDirectory(skillFolderPath);
+            foreach (var (folder, _) in AdditionalSkills)
+                CleanupEmptyDirectory(Path.Combine(skillsDir, folder));
+            CleanupEmptyDirectory(skillsDir);
         }
         catch
         {
@@ -474,11 +504,40 @@ public static class SkillCommands
 
         if (json)
         {
-            Console.WriteLine(JsonHelper.Serialize(new { success = true, path = skillPath }));
+            Console.WriteLine(JsonHelper.Serialize(new { success = true, path = skillsDir }));
         }
         else
         {
-            Console.WriteLine($"Removed skill from: {skillPath}");
+            Console.WriteLine($"Removed skills from: {skillsDir}");
+        }
+    }
+
+    private static void CleanupEmptyDirectory(string path)
+    {
+        if (Directory.Exists(path) && !Directory.EnumerateFileSystemEntries(path).Any())
+            Directory.Delete(path);
+    }
+
+    /// <summary>
+    /// Installs additional skill files alongside the main unity-editor skill.
+    /// When onlyIfExists is true, only updates skills that already have a folder.
+    /// </summary>
+    private static async Task InstallAdditionalSkillsAsync(string skillsDir, bool onlyIfExists)
+    {
+        foreach (var (folder, resource) in AdditionalSkills)
+        {
+            var folderPath = Path.Combine(skillsDir, folder);
+            var filePath = Path.Combine(folderPath, SkillFileName);
+
+            if (onlyIfExists && !File.Exists(filePath))
+                continue;
+
+            var content = GetEmbeddedResourceContent(resource, folder);
+            if (content == null)
+                continue;
+
+            Directory.CreateDirectory(folderPath);
+            await File.WriteAllTextAsync(filePath, content);
         }
     }
 
@@ -488,34 +547,42 @@ public static class SkillCommands
         var globalSkillsDir = Path.Combine(home, ".claude", "skills");
         var localSkillsDir = Path.Combine(Directory.GetCurrentDirectory(), ".claude", "skills");
 
-        var globalPath = Path.Combine(globalSkillsDir, SkillFolderName, SkillFileName);
-        var localPath = Path.Combine(localSkillsDir, SkillFolderName, SkillFileName);
-
-        var globalExists = File.Exists(globalPath);
-        var localExists = File.Exists(localPath);
+        // All skill folders to check
+        var allFolders = new[] { SkillFolderName }.Concat(AdditionalSkills.Select(s => s.Folder)).ToArray();
 
         if (json)
         {
-            Console.WriteLine(JsonHelper.Serialize(new
+            var skills = allFolders.Select(folder => new
             {
-                global = new { installed = globalExists, path = globalPath },
-                local = new { installed = localExists, path = localPath }
-            }));
+                name = folder,
+                global = new { installed = File.Exists(Path.Combine(globalSkillsDir, folder, SkillFileName)), path = Path.Combine(globalSkillsDir, folder, SkillFileName) },
+                local = new { installed = File.Exists(Path.Combine(localSkillsDir, folder, SkillFileName)), path = Path.Combine(localSkillsDir, folder, SkillFileName) }
+            });
+            Console.WriteLine(JsonHelper.Serialize(skills));
         }
         else
         {
             Console.WriteLine("Claude Code Skill Status:");
-            Console.WriteLine();
-            Console.WriteLine($"Global ({globalPath}):");
-            Console.WriteLine($"  Installed: {(globalExists ? "Yes" : "No")}");
-            Console.WriteLine();
-            Console.WriteLine($"Local ({localPath}):");
-            Console.WriteLine($"  Installed: {(localExists ? "Yes" : "No")}");
 
-            if (!globalExists && !localExists)
+            var anyInstalled = false;
+            foreach (var folder in allFolders)
+            {
+                var globalPath = Path.Combine(globalSkillsDir, folder, SkillFileName);
+                var localPath = Path.Combine(localSkillsDir, folder, SkillFileName);
+                var globalExists = File.Exists(globalPath);
+                var localExists = File.Exists(localPath);
+                if (globalExists || localExists) anyInstalled = true;
+
+                Console.WriteLine();
+                Console.WriteLine($"  {folder}:");
+                Console.WriteLine($"    Global: {(globalExists ? "Yes" : "No")}");
+                Console.WriteLine($"    Local:  {(localExists ? "Yes" : "No")}");
+            }
+
+            if (!anyInstalled)
             {
                 Console.WriteLine();
-                Console.WriteLine("Run 'unityctl skill add' to add the skill locally,");
+                Console.WriteLine("Run 'unityctl skill add' to add skills locally,");
                 Console.WriteLine("or 'unityctl skill add --global' to add globally.");
             }
         }

--- a/UnityCtl.Cli/UnityCtl.Cli.csproj
+++ b/UnityCtl.Cli/UnityCtl.Cli.csproj
@@ -20,10 +20,10 @@
     <ProjectReference Include="..\UnityCtl.Protocol\UnityCtl.Protocol.csproj" />
   </ItemGroup>
 
-  <!-- Embed SKILL.md files as resources for skill installation -->
+  <!-- Embed base SKILL.md files as resources for skill installation -->
   <ItemGroup>
-    <EmbeddedResource Include="..\.claude\skills\unity-editor\SKILL.md" Link="Resources\SKILL.md" LogicalName="UnityCtl.Cli.Resources.SKILL.md" />
-    <EmbeddedResource Include="..\.claude\skills\unityctl-plugins\SKILL.md" Link="Resources\SKILL.plugins.md" LogicalName="UnityCtl.Cli.Resources.SKILL.plugins.md" />
+    <EmbeddedResource Include="Resources\SKILL.md" LogicalName="UnityCtl.Cli.Resources.SKILL.md" />
+    <EmbeddedResource Include="Resources\SKILL.plugins.md" LogicalName="UnityCtl.Cli.Resources.SKILL.plugins.md" />
   </ItemGroup>
 
 </Project>

--- a/UnityCtl.Cli/UnityCtl.Cli.csproj
+++ b/UnityCtl.Cli/UnityCtl.Cli.csproj
@@ -20,9 +20,10 @@
     <ProjectReference Include="..\UnityCtl.Protocol\UnityCtl.Protocol.csproj" />
   </ItemGroup>
 
-  <!-- Embed SKILL.md as a resource for skill installation -->
+  <!-- Embed SKILL.md files as resources for skill installation -->
   <ItemGroup>
     <EmbeddedResource Include="..\.claude\skills\unity-editor\SKILL.md" Link="Resources\SKILL.md" LogicalName="UnityCtl.Cli.Resources.SKILL.md" />
+    <EmbeddedResource Include="..\.claude\skills\unityctl-plugins\SKILL.md" Link="Resources\SKILL.plugins.md" LogicalName="UnityCtl.Cli.Resources.SKILL.plugins.md" />
   </ItemGroup>
 
 </Project>

--- a/UnityCtl.Cli/UnityCtl.Cli.csproj
+++ b/UnityCtl.Cli/UnityCtl.Cli.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="UnityCtl.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Management" Version="9.0.0" />
   </ItemGroup>

--- a/UnityCtl.Tests/Unit/Cli/BaseSkillIntegrityTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/BaseSkillIntegrityTests.cs
@@ -59,8 +59,7 @@ public class BaseSkillIntegrityTests
     [Fact]
     public void SourceSkillMd_OnDisk_DoesNotContainPluginSections()
     {
-        // Find the source SKILL.md relative to the test assembly
-        // The repo structure is: repo/.claude/skills/unity-editor/SKILL.md
+        // The base skill source lives in UnityCtl.Cli/Resources/SKILL.md
         var assemblyDir = Path.GetDirectoryName(typeof(BaseSkillIntegrityTests).Assembly.Location)!;
 
         // Walk up to find repo root (look for .git)
@@ -79,7 +78,7 @@ public class BaseSkillIntegrityTests
         // Skip if we can't find the repo root (e.g., running from a package)
         Skip.If(repoRoot == null, "Could not find repo root");
 
-        var skillPath = Path.Combine(repoRoot!, ".claude", "skills", "unity-editor", "SKILL.md");
+        var skillPath = Path.Combine(repoRoot!, "UnityCtl.Cli", "Resources", "SKILL.md");
         Skip.IfNot(File.Exists(skillPath), $"SKILL.md not found at {skillPath}");
 
         var content = File.ReadAllText(skillPath);

--- a/UnityCtl.Tests/Unit/Cli/BaseSkillIntegrityTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/BaseSkillIntegrityTests.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace UnityCtl.Tests.Unit.Cli;
+
+/// <summary>
+/// Verifies that the base SKILL.md files (embedded as resources and committed to the repo)
+/// are clean base versions without composed plugin sections. This prevents accidentally
+/// committing a composed SKILL.md (from 'skill rebuild') as the source of truth.
+/// </summary>
+public class BaseSkillIntegrityTests
+{
+    private const string PluginSectionMarker = "## Plugin Commands";
+
+    [Fact]
+    public void EmbeddedSkillMd_DoesNotContainPluginSections()
+    {
+        var assembly = typeof(UnityCtl.Cli.SkillCommands).Assembly;
+        using var stream = assembly.GetManifestResourceStream("UnityCtl.Cli.Resources.SKILL.md");
+
+        Assert.NotNull(stream);
+
+        using var reader = new StreamReader(stream!);
+        var content = reader.ReadToEnd();
+
+        Assert.DoesNotContain(PluginSectionMarker, content);
+    }
+
+    [Fact]
+    public void EmbeddedSkillMd_HasFrontmatter()
+    {
+        var assembly = typeof(UnityCtl.Cli.SkillCommands).Assembly;
+        using var stream = assembly.GetManifestResourceStream("UnityCtl.Cli.Resources.SKILL.md");
+
+        Assert.NotNull(stream);
+
+        using var reader = new StreamReader(stream!);
+        var content = reader.ReadToEnd();
+
+        Assert.StartsWith("---", content);
+        Assert.Contains("name: unity-editor", content);
+    }
+
+    [Fact]
+    public void EmbeddedPluginSkillMd_Exists()
+    {
+        var assembly = typeof(UnityCtl.Cli.SkillCommands).Assembly;
+        using var stream = assembly.GetManifestResourceStream("UnityCtl.Cli.Resources.SKILL.plugins.md");
+
+        Assert.NotNull(stream);
+
+        using var reader = new StreamReader(stream!);
+        var content = reader.ReadToEnd();
+
+        Assert.Contains("unityctl-plugins", content);
+    }
+
+    [Fact]
+    public void SourceSkillMd_OnDisk_DoesNotContainPluginSections()
+    {
+        // Find the source SKILL.md relative to the test assembly
+        // The repo structure is: repo/.claude/skills/unity-editor/SKILL.md
+        var assemblyDir = Path.GetDirectoryName(typeof(BaseSkillIntegrityTests).Assembly.Location)!;
+
+        // Walk up to find repo root (look for .git)
+        var dir = new DirectoryInfo(assemblyDir);
+        string? repoRoot = null;
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            {
+                repoRoot = dir.FullName;
+                break;
+            }
+            dir = dir.Parent;
+        }
+
+        // Skip if we can't find the repo root (e.g., running from a package)
+        Skip.If(repoRoot == null, "Could not find repo root");
+
+        var skillPath = Path.Combine(repoRoot!, ".claude", "skills", "unity-editor", "SKILL.md");
+        Skip.IfNot(File.Exists(skillPath), $"SKILL.md not found at {skillPath}");
+
+        var content = File.ReadAllText(skillPath);
+
+        Assert.DoesNotContain(PluginSectionMarker, content);
+    }
+}

--- a/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
@@ -154,6 +154,54 @@ public class ExecutablePluginScanTests : IDisposable
         Assert.Empty(plugins);
     }
 
+    [Fact]
+    public void ReadShebang_EnvBash_ReturnsBash()
+    {
+        var path = CreateScript("#!/usr/bin/env bash\necho hello");
+        Assert.Equal("bash", ExecutablePluginLoader.ReadShebangInterpreter(path));
+    }
+
+    [Fact]
+    public void ReadShebang_AbsolutePath_ReturnsFileName()
+    {
+        var path = CreateScript("#!/bin/bash\necho hello");
+        Assert.Equal("bash", ExecutablePluginLoader.ReadShebangInterpreter(path));
+    }
+
+    [Fact]
+    public void ReadShebang_EnvPython_ReturnsPython()
+    {
+        var path = CreateScript("#!/usr/bin/env python3\nimport sys");
+        Assert.Equal("python3", ExecutablePluginLoader.ReadShebangInterpreter(path));
+    }
+
+    [Fact]
+    public void ReadShebang_NoShebang_ReturnsNull()
+    {
+        var path = CreateScript("echo hello\n");
+        Assert.Null(ExecutablePluginLoader.ReadShebangInterpreter(path));
+    }
+
+    [Fact]
+    public void ReadShebang_EmptyFile_ReturnsNull()
+    {
+        var path = CreateScript("");
+        Assert.Null(ExecutablePluginLoader.ReadShebangInterpreter(path));
+    }
+
+    [Fact]
+    public void ReadShebang_NonexistentFile_ReturnsNull()
+    {
+        Assert.Null(ExecutablePluginLoader.ReadShebangInterpreter(Path.Combine(_tempDir, "nope")));
+    }
+
+    private string CreateScript(string content)
+    {
+        var path = Path.Combine(_tempDir, $"script-{Guid.NewGuid():N}");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
     private void CreateExecutable(string fileName)
     {
         var path = Path.Combine(_tempDir, fileName);

--- a/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
@@ -8,7 +8,8 @@ using Xunit;
 namespace UnityCtl.Tests.Unit.Cli;
 
 /// <summary>
-/// Tests executable plugin discovery from directories using the actual ScanDirectoryForExecutables method.
+/// Tests executable plugin discovery by calling ExecutablePluginLoader.ScanDirectoryForExecutables
+/// against temp directories with real files.
 /// </summary>
 public class ExecutablePluginScanTests : IDisposable
 {
@@ -25,62 +26,66 @@ public class ExecutablePluginScanTests : IDisposable
         try { Directory.Delete(_tempDir, recursive: true); } catch { }
     }
 
-    [Fact]
-    public void NameExtraction_WithAndWithoutExtension()
+    [SkippableFact]
+    public void Discovers_Extensionless_Executable()
     {
-        // Create test files
         CreateExecutable("unityctl-foo");
+
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
+        Assert.Single(plugins);
+        Assert.Equal("foo", plugins[0].Name);
+    }
+
+    [SkippableFact]
+    public void Discovers_Exe_Extension()
+    {
         CreateExecutable("unityctl-bar.exe");
+
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
+        Assert.Single(plugins);
+        Assert.Equal("bar", plugins[0].Name);
+    }
+
+    [SkippableFact]
+    public void Discovers_Cmd_Extension()
+    {
         CreateExecutable("unityctl-baz.cmd");
-        CreateExecutable("unityctl-qux.bat");
-        CreateExecutable("unityctl-run.sh");
 
-        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
 
-        Assert.Contains(plugins, p => p.Name == "foo");
-        Assert.Contains(plugins, p => p.Name == "bar");
-        Assert.Contains(plugins, p => p.Name == "baz");
-        Assert.Contains(plugins, p => p.Name == "qux");
-        Assert.Contains(plugins, p => p.Name == "run");
+        Assert.Single(plugins);
+        Assert.Equal("baz", plugins[0].Name);
     }
 
     [Fact]
-    public void CompanionSkillFile_Ignored()
+    public void CompanionSkillFile_NotDiscovered()
     {
-        // .skill.md companion files should not be discovered as executable plugins
         File.WriteAllText(Path.Combine(_tempDir, "unityctl-foo.skill.md"), "docs");
-        File.WriteAllText(Path.Combine(_tempDir, "unityctl-bar.skill.md"), "docs");
 
-        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
         Assert.Empty(plugins);
     }
 
-    [Fact]
-    public void Extensionless_ExtractsName()
+    [SkippableFact]
+    public void EmptyNameAfterPrefix_Skipped()
     {
-        CreateExecutable("unityctl-my-tool");
-
-        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
-        Assert.Single(plugins);
-        Assert.Equal("my-tool", plugins[0].Name);
-    }
-
-    [Fact]
-    public void EmptyPrefix_Skipped()
-    {
-        // "unityctl-.exe" should produce an empty name and be skipped
         CreateExecutable("unityctl-.exe");
 
-        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
         Assert.Empty(plugins);
     }
 
-    [Fact]
-    public void NameExtraction_Lowercased()
+    [SkippableFact]
+    public void Name_IsLowercased()
     {
         CreateExecutable("unityctl-MyPlugin");
 
-        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
         Assert.Single(plugins);
         Assert.Equal("myplugin", plugins[0].Name);
     }
@@ -88,42 +93,65 @@ public class ExecutablePluginScanTests : IDisposable
     [Fact]
     public void NonMatchingFiles_Ignored()
     {
-        // Files that don't start with "unityctl-" should not be discovered
         File.WriteAllText(Path.Combine(_tempDir, "other-tool.exe"), "fake");
-        File.WriteAllText(Path.Combine(_tempDir, "unityctl.exe"), "fake"); // no hyphen after
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl.exe"), "fake"); // no hyphen after prefix
 
-        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
         Assert.Empty(plugins);
     }
 
-    [Fact]
-    public void UnixNameExtraction_StripsExtension()
-    {
-        CreateExecutable("unityctl-foo.sh");
-
-        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
-        Assert.Single(plugins);
-        Assert.Equal("foo", plugins[0].Name);
-    }
-
-    [Fact]
+    [SkippableFact]
     public void Source_IsPassedThrough()
     {
         CreateExecutable("unityctl-test-tool");
 
         var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
         Assert.Single(plugins);
         Assert.Equal("project", plugins[0].Source);
     }
 
-    [Fact]
+    [SkippableFact]
     public void Path_IsFullFilePath()
     {
         CreateExecutable("unityctl-check");
 
-        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
         Assert.Single(plugins);
         Assert.StartsWith(_tempDir, plugins[0].Path);
+    }
+
+    [SkippableFact]
+    public void MultipleExecutables_AllDiscovered()
+    {
+        CreateExecutable("unityctl-alpha.exe");
+        CreateExecutable("unityctl-beta.cmd");
+
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
+        Assert.Equal(2, plugins.Count);
+        Assert.Contains(plugins, p => p.Name == "alpha");
+        Assert.Contains(plugins, p => p.Name == "beta");
+    }
+
+    [Fact]
+    public void EmptyDirectory_ReturnsEmpty()
+    {
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+
+        Assert.Empty(plugins);
+    }
+
+    [Fact]
+    public void NonexistentDirectory_ReturnsEmpty()
+    {
+        var nonexistent = Path.Combine(_tempDir, "does-not-exist");
+
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(nonexistent, "project").ToList();
+
+        Assert.Empty(plugins);
     }
 
     private void CreateExecutable(string fileName)

--- a/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
@@ -26,46 +26,55 @@ public class ExecutablePluginScanTests : IDisposable
         try { Directory.Delete(_tempDir, recursive: true); } catch { }
     }
 
-    [SkippableFact]
-    public void WindowsExe_ExtractsName()
+    [Fact]
+    public void NameExtraction_WithAndWithoutExtension()
     {
-        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-
-        File.WriteAllText(Path.Combine(_tempDir, "unityctl-foo.exe"), "fake");
-        File.WriteAllText(Path.Combine(_tempDir, "unityctl-bar.cmd"), "fake");
-        File.WriteAllText(Path.Combine(_tempDir, "unityctl-baz.bat"), "fake");
-
-        // Scan using the internal method via discovery (which scans plugin dirs)
-        // We test the naming logic by verifying the full scan result
-        var files = Directory.GetFiles(_tempDir, "unityctl-*");
-        Assert.Equal(3, files.Length);
-
-        // Verify the naming convention: file name without extension, minus prefix
-        foreach (var file in files)
+        // All naming variants: extensionless, .exe, .cmd, .bat, .sh
+        var cases = new[]
         {
-            var fileName = Path.GetFileNameWithoutExtension(file);
-            Assert.StartsWith("unityctl-", fileName);
+            ("unityctl-foo", "foo"),
+            ("unityctl-bar.exe", "bar"),
+            ("unityctl-baz.cmd", "baz"),
+            ("unityctl-qux.bat", "qux"),
+            ("unityctl-run.sh", "run"),
+        };
+
+        foreach (var (fileName, expected) in cases)
+        {
             var name = fileName.Substring("unityctl-".Length);
-            Assert.False(string.IsNullOrEmpty(name));
+            var dotIndex = name.IndexOf('.');
+            if (dotIndex > 0)
+                name = name.Substring(0, dotIndex);
+
+            Assert.Equal(expected, name.ToLowerInvariant());
         }
     }
 
-    [SkippableFact]
-    public void Windows_NonExecutableExtension_Ignored()
+    [Fact]
+    public void CompanionSkillFile_Ignored()
     {
-        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+        // .skill.md companion files should not be discovered as executable plugins
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl-foo.skill.md"), "docs");
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl-bar.skill.md"), "docs");
 
-        // .txt files should not be discovered as executable plugins
-        File.WriteAllText(Path.Combine(_tempDir, "unityctl-nope.txt"), "fake");
-        File.WriteAllText(Path.Combine(_tempDir, "unityctl-also-nope.py"), "fake");
-
-        // The scan should filter these out based on extension
-        var validExtensions = new[] { ".exe", ".cmd", ".bat", ".ps1" };
         var files = Directory.GetFiles(_tempDir, "unityctl-*");
-        var validFiles = files.Where(f =>
-            validExtensions.Contains(Path.GetExtension(f).ToLowerInvariant())).ToList();
+        var nonCompanion = files.Where(f =>
+            !Path.GetFileName(f).EndsWith(".skill.md", StringComparison.OrdinalIgnoreCase)).ToList();
 
-        Assert.Empty(validFiles);
+        Assert.Empty(nonCompanion);
+    }
+
+    [Fact]
+    public void Extensionless_ExtractsName()
+    {
+        // Extensionless executables should be discovered on all platforms
+        var fullFileName = "unityctl-my-tool";
+        var name = fullFileName.Substring("unityctl-".Length);
+        var dotIndex = name.IndexOf('.');
+        if (dotIndex > 0)
+            name = name.Substring(0, dotIndex);
+
+        Assert.Equal("my-tool", name);
     }
 
     [Fact]
@@ -112,15 +121,4 @@ public class ExecutablePluginScanTests : IDisposable
         Assert.Equal("foo", name);
     }
 
-    [Fact]
-    public void UnixNameExtraction_NoExtension_KeepsFullName()
-    {
-        var fullFileName = "unityctl-my-tool";
-        var name = fullFileName.Substring("unityctl-".Length);
-        var dotIndex = name.IndexOf('.');
-        if (dotIndex > 0)
-            name = name.Substring(0, dotIndex);
-
-        Assert.Equal("my-tool", name);
-    }
 }

--- a/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using UnityCtl.Cli;
+using Xunit;
+
+namespace UnityCtl.Tests.Unit.Cli;
+
+/// <summary>
+/// Tests executable plugin discovery from directories.
+/// Uses DiscoverExecutablePlugins with plugin directories containing test executables.
+/// </summary>
+public class ExecutablePluginScanTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ExecutablePluginScanTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"unityctl-exec-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [SkippableFact]
+    public void WindowsExe_ExtractsName()
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl-foo.exe"), "fake");
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl-bar.cmd"), "fake");
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl-baz.bat"), "fake");
+
+        // Scan using the internal method via discovery (which scans plugin dirs)
+        // We test the naming logic by verifying the full scan result
+        var files = Directory.GetFiles(_tempDir, "unityctl-*");
+        Assert.Equal(3, files.Length);
+
+        // Verify the naming convention: file name without extension, minus prefix
+        foreach (var file in files)
+        {
+            var fileName = Path.GetFileNameWithoutExtension(file);
+            Assert.StartsWith("unityctl-", fileName);
+            var name = fileName.Substring("unityctl-".Length);
+            Assert.False(string.IsNullOrEmpty(name));
+        }
+    }
+
+    [SkippableFact]
+    public void Windows_NonExecutableExtension_Ignored()
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
+        // .txt files should not be discovered as executable plugins
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl-nope.txt"), "fake");
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl-also-nope.py"), "fake");
+
+        // The scan should filter these out based on extension
+        var validExtensions = new[] { ".exe", ".cmd", ".bat", ".ps1" };
+        var files = Directory.GetFiles(_tempDir, "unityctl-*");
+        var validFiles = files.Where(f =>
+            validExtensions.Contains(Path.GetExtension(f).ToLowerInvariant())).ToList();
+
+        Assert.Empty(validFiles);
+    }
+
+    [Fact]
+    public void EmptyPrefix_Skipped()
+    {
+        // "unityctl-.exe" should produce an empty name and be skipped
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl-.exe"), "fake");
+
+        var fileName = Path.GetFileNameWithoutExtension("unityctl-.exe");
+        var name = fileName.Substring("unityctl-".Length);
+        Assert.True(string.IsNullOrEmpty(name));
+    }
+
+    [Fact]
+    public void NameExtraction_Lowercased()
+    {
+        // Verify that extracted names are lowercased
+        var fileName = "unityctl-MyPlugin";
+        var name = fileName.Substring("unityctl-".Length).ToLowerInvariant();
+        Assert.Equal("myplugin", name);
+    }
+
+    [Fact]
+    public void NonMatchingFiles_Ignored()
+    {
+        // Files that don't start with "unityctl-" should not be discovered
+        File.WriteAllText(Path.Combine(_tempDir, "other-tool.exe"), "fake");
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl.exe"), "fake"); // no hyphen after
+
+        var files = Directory.GetFiles(_tempDir, "unityctl-*");
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public void UnixNameExtraction_StripsExtension()
+    {
+        // On Unix, "unityctl-foo.sh" should extract "foo" (extension stripped)
+        var fullFileName = "unityctl-foo.sh";
+        var name = fullFileName.Substring("unityctl-".Length);
+        var dotIndex = name.IndexOf('.');
+        if (dotIndex > 0)
+            name = name.Substring(0, dotIndex);
+
+        Assert.Equal("foo", name);
+    }
+
+    [Fact]
+    public void UnixNameExtraction_NoExtension_KeepsFullName()
+    {
+        var fullFileName = "unityctl-my-tool";
+        var name = fullFileName.Substring("unityctl-".Length);
+        var dotIndex = name.IndexOf('.');
+        if (dotIndex > 0)
+            name = name.Substring(0, dotIndex);
+
+        Assert.Equal("my-tool", name);
+    }
+}

--- a/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/ExecutablePluginScanTests.cs
@@ -8,8 +8,7 @@ using Xunit;
 namespace UnityCtl.Tests.Unit.Cli;
 
 /// <summary>
-/// Tests executable plugin discovery from directories.
-/// Uses DiscoverExecutablePlugins with plugin directories containing test executables.
+/// Tests executable plugin discovery from directories using the actual ScanDirectoryForExecutables method.
 /// </summary>
 public class ExecutablePluginScanTests : IDisposable
 {
@@ -29,25 +28,20 @@ public class ExecutablePluginScanTests : IDisposable
     [Fact]
     public void NameExtraction_WithAndWithoutExtension()
     {
-        // All naming variants: extensionless, .exe, .cmd, .bat, .sh
-        var cases = new[]
-        {
-            ("unityctl-foo", "foo"),
-            ("unityctl-bar.exe", "bar"),
-            ("unityctl-baz.cmd", "baz"),
-            ("unityctl-qux.bat", "qux"),
-            ("unityctl-run.sh", "run"),
-        };
+        // Create test files
+        CreateExecutable("unityctl-foo");
+        CreateExecutable("unityctl-bar.exe");
+        CreateExecutable("unityctl-baz.cmd");
+        CreateExecutable("unityctl-qux.bat");
+        CreateExecutable("unityctl-run.sh");
 
-        foreach (var (fileName, expected) in cases)
-        {
-            var name = fileName.Substring("unityctl-".Length);
-            var dotIndex = name.IndexOf('.');
-            if (dotIndex > 0)
-                name = name.Substring(0, dotIndex);
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
 
-            Assert.Equal(expected, name.ToLowerInvariant());
-        }
+        Assert.Contains(plugins, p => p.Name == "foo");
+        Assert.Contains(plugins, p => p.Name == "bar");
+        Assert.Contains(plugins, p => p.Name == "baz");
+        Assert.Contains(plugins, p => p.Name == "qux");
+        Assert.Contains(plugins, p => p.Name == "run");
     }
 
     [Fact]
@@ -57,44 +51,38 @@ public class ExecutablePluginScanTests : IDisposable
         File.WriteAllText(Path.Combine(_tempDir, "unityctl-foo.skill.md"), "docs");
         File.WriteAllText(Path.Combine(_tempDir, "unityctl-bar.skill.md"), "docs");
 
-        var files = Directory.GetFiles(_tempDir, "unityctl-*");
-        var nonCompanion = files.Where(f =>
-            !Path.GetFileName(f).EndsWith(".skill.md", StringComparison.OrdinalIgnoreCase)).ToList();
-
-        Assert.Empty(nonCompanion);
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        Assert.Empty(plugins);
     }
 
     [Fact]
     public void Extensionless_ExtractsName()
     {
-        // Extensionless executables should be discovered on all platforms
-        var fullFileName = "unityctl-my-tool";
-        var name = fullFileName.Substring("unityctl-".Length);
-        var dotIndex = name.IndexOf('.');
-        if (dotIndex > 0)
-            name = name.Substring(0, dotIndex);
+        CreateExecutable("unityctl-my-tool");
 
-        Assert.Equal("my-tool", name);
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        Assert.Single(plugins);
+        Assert.Equal("my-tool", plugins[0].Name);
     }
 
     [Fact]
     public void EmptyPrefix_Skipped()
     {
         // "unityctl-.exe" should produce an empty name and be skipped
-        File.WriteAllText(Path.Combine(_tempDir, "unityctl-.exe"), "fake");
+        CreateExecutable("unityctl-.exe");
 
-        var fileName = Path.GetFileNameWithoutExtension("unityctl-.exe");
-        var name = fileName.Substring("unityctl-".Length);
-        Assert.True(string.IsNullOrEmpty(name));
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        Assert.Empty(plugins);
     }
 
     [Fact]
     public void NameExtraction_Lowercased()
     {
-        // Verify that extracted names are lowercased
-        var fileName = "unityctl-MyPlugin";
-        var name = fileName.Substring("unityctl-".Length).ToLowerInvariant();
-        Assert.Equal("myplugin", name);
+        CreateExecutable("unityctl-MyPlugin");
+
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        Assert.Single(plugins);
+        Assert.Equal("myplugin", plugins[0].Name);
     }
 
     [Fact]
@@ -104,21 +92,49 @@ public class ExecutablePluginScanTests : IDisposable
         File.WriteAllText(Path.Combine(_tempDir, "other-tool.exe"), "fake");
         File.WriteAllText(Path.Combine(_tempDir, "unityctl.exe"), "fake"); // no hyphen after
 
-        var files = Directory.GetFiles(_tempDir, "unityctl-*");
-        Assert.Empty(files);
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        Assert.Empty(plugins);
     }
 
     [Fact]
     public void UnixNameExtraction_StripsExtension()
     {
-        // On Unix, "unityctl-foo.sh" should extract "foo" (extension stripped)
-        var fullFileName = "unityctl-foo.sh";
-        var name = fullFileName.Substring("unityctl-".Length);
-        var dotIndex = name.IndexOf('.');
-        if (dotIndex > 0)
-            name = name.Substring(0, dotIndex);
+        CreateExecutable("unityctl-foo.sh");
 
-        Assert.Equal("foo", name);
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        Assert.Single(plugins);
+        Assert.Equal("foo", plugins[0].Name);
     }
 
+    [Fact]
+    public void Source_IsPassedThrough()
+    {
+        CreateExecutable("unityctl-test-tool");
+
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "project").ToList();
+        Assert.Single(plugins);
+        Assert.Equal("project", plugins[0].Source);
+    }
+
+    [Fact]
+    public void Path_IsFullFilePath()
+    {
+        CreateExecutable("unityctl-check");
+
+        var plugins = ExecutablePluginLoader.ScanDirectoryForExecutables(_tempDir, "test").ToList();
+        Assert.Single(plugins);
+        Assert.StartsWith(_tempDir, plugins[0].Path);
+    }
+
+    private void CreateExecutable(string fileName)
+    {
+        var path = Path.Combine(_tempDir, fileName);
+        File.WriteAllText(path, "fake");
+
+        // On Unix, set the executable permission
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            System.Diagnostics.Process.Start("chmod", ["+x", path])?.WaitForExit();
+        }
+    }
 }

--- a/UnityCtl.Tests/Unit/Cli/PluginManifestTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/PluginManifestTests.cs
@@ -1,0 +1,191 @@
+using System;
+using Newtonsoft.Json;
+using UnityCtl.Cli;
+using Xunit;
+
+namespace UnityCtl.Tests.Unit.Cli;
+
+public class PluginManifestTests
+{
+    [Fact]
+    public void Deserialize_FullManifest_AllFieldsPopulated()
+    {
+        var json = """
+        {
+          "name": "my-tool",
+          "version": "2.1.0",
+          "description": "A cool tool",
+          "commands": [
+            {
+              "name": "run",
+              "description": "Run the tool",
+              "arguments": [
+                { "name": "target", "description": "Target name", "required": true }
+              ],
+              "options": [
+                { "name": "verbose", "type": "bool", "description": "Verbose output" },
+                { "name": "format", "type": "string", "description": "Output format" }
+              ],
+              "handler": { "type": "script", "file": "run.cs" }
+            }
+          ],
+          "skill": { "file": "SKILL-SECTION.md" }
+        }
+        """;
+
+        var manifest = JsonConvert.DeserializeObject<PluginManifest>(json)!;
+
+        Assert.Equal("my-tool", manifest.Name);
+        Assert.Equal("2.1.0", manifest.Version);
+        Assert.Equal("A cool tool", manifest.Description);
+        Assert.Single(manifest.Commands);
+
+        var cmd = manifest.Commands[0];
+        Assert.Equal("run", cmd.Name);
+        Assert.Equal("Run the tool", cmd.Description);
+        Assert.Single(cmd.Arguments);
+        Assert.Equal("target", cmd.Arguments[0].Name);
+        Assert.True(cmd.Arguments[0].Required);
+        Assert.Equal(2, cmd.Options.Length);
+        Assert.Equal("verbose", cmd.Options[0].Name);
+        Assert.Equal("bool", cmd.Options[0].Type);
+        Assert.Equal("format", cmd.Options[1].Name);
+        Assert.Equal("string", cmd.Options[1].Type);
+        Assert.Equal("script", cmd.Handler.Type);
+        Assert.Equal("run.cs", cmd.Handler.File);
+
+        Assert.NotNull(manifest.Skill);
+        Assert.Equal("SKILL-SECTION.md", manifest.Skill!.File);
+    }
+
+    [Fact]
+    public void Deserialize_MinimalManifest_DefaultsPopulated()
+    {
+        var json = """
+        {
+          "name": "bare",
+          "commands": [
+            {
+              "name": "do",
+              "handler": { "file": "do.cs" }
+            }
+          ]
+        }
+        """;
+
+        var manifest = JsonConvert.DeserializeObject<PluginManifest>(json)!;
+
+        Assert.Equal("bare", manifest.Name);
+        Assert.Null(manifest.Version);
+        Assert.Null(manifest.Description);
+        Assert.Single(manifest.Commands);
+
+        var cmd = manifest.Commands[0];
+        Assert.Null(cmd.Description);
+        Assert.Empty(cmd.Arguments);
+        Assert.Empty(cmd.Options);
+        Assert.Equal("script", cmd.Handler.Type); // default
+        Assert.Null(manifest.Skill);
+    }
+
+    [Fact]
+    public void Deserialize_NoCommands_EmptyArray()
+    {
+        var json = """{ "name": "empty" }""";
+
+        var manifest = JsonConvert.DeserializeObject<PluginManifest>(json)!;
+
+        Assert.Equal("empty", manifest.Name);
+        Assert.Empty(manifest.Commands);
+    }
+
+    [Fact]
+    public void Deserialize_UnknownFields_Ignored()
+    {
+        var json = """
+        {
+          "name": "future",
+          "futureField": true,
+          "commands": [
+            {
+              "name": "cmd",
+              "handler": { "file": "cmd.cs", "runtime": "mono" }
+            }
+          ]
+        }
+        """;
+
+        var manifest = JsonConvert.DeserializeObject<PluginManifest>(json)!;
+
+        Assert.Equal("future", manifest.Name);
+        Assert.Single(manifest.Commands);
+    }
+
+    [Fact]
+    public void Deserialize_MultipleCommands_AllPreserved()
+    {
+        var json = """
+        {
+          "name": "multi",
+          "commands": [
+            { "name": "a", "handler": { "file": "a.cs" } },
+            { "name": "b", "handler": { "file": "b.cs" } },
+            { "name": "c", "handler": { "file": "c.cs" } }
+          ]
+        }
+        """;
+
+        var manifest = JsonConvert.DeserializeObject<PluginManifest>(json)!;
+
+        Assert.Equal(3, manifest.Commands.Length);
+        Assert.Equal("a", manifest.Commands[0].Name);
+        Assert.Equal("b", manifest.Commands[1].Name);
+        Assert.Equal("c", manifest.Commands[2].Name);
+    }
+
+    [Fact]
+    public void Deserialize_OptionTypeDefaults_ToString()
+    {
+        var json = """
+        {
+          "name": "opt-test",
+          "commands": [
+            {
+              "name": "cmd",
+              "options": [
+                { "name": "no-type" }
+              ],
+              "handler": { "file": "cmd.cs" }
+            }
+          ]
+        }
+        """;
+
+        var manifest = JsonConvert.DeserializeObject<PluginManifest>(json)!;
+
+        Assert.Equal("string", manifest.Commands[0].Options[0].Type);
+    }
+
+    [Fact]
+    public void Deserialize_ArgumentRequired_DefaultsFalse()
+    {
+        var json = """
+        {
+          "name": "arg-test",
+          "commands": [
+            {
+              "name": "cmd",
+              "arguments": [
+                { "name": "optional-arg" }
+              ],
+              "handler": { "file": "cmd.cs" }
+            }
+          ]
+        }
+        """;
+
+        var manifest = JsonConvert.DeserializeObject<PluginManifest>(json)!;
+
+        Assert.False(manifest.Commands[0].Arguments[0].Required);
+    }
+}

--- a/UnityCtl.Tests/Unit/Cli/PluginNameValidationTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/PluginNameValidationTests.cs
@@ -1,16 +1,15 @@
 using System.Text.RegularExpressions;
+using UnityCtl.Cli;
 using Xunit;
 
 namespace UnityCtl.Tests.Unit.Cli;
 
 /// <summary>
 /// Tests the plugin name validation regex used by 'plugin create'.
-/// The regex is: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
 /// </summary>
 public class PluginNameValidationTests
 {
-    // Same regex as PluginCommands.ValidPluginName
-    private static readonly Regex ValidPluginName = new(@"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", RegexOptions.Compiled);
+    private static readonly Regex ValidPluginName = PluginCommands.ValidPluginName;
 
     [Theory]
     [InlineData("foo")]

--- a/UnityCtl.Tests/Unit/Cli/PluginNameValidationTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/PluginNameValidationTests.cs
@@ -1,0 +1,60 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace UnityCtl.Tests.Unit.Cli;
+
+/// <summary>
+/// Tests the plugin name validation regex used by 'plugin create'.
+/// The regex is: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
+/// </summary>
+public class PluginNameValidationTests
+{
+    // Same regex as PluginCommands.ValidPluginName
+    private static readonly Regex ValidPluginName = new(@"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", RegexOptions.Compiled);
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData("my-tool")]
+    [InlineData("a")]
+    [InlineData("a1")]
+    [InlineData("1a")]
+    [InlineData("my-long-plugin-name")]
+    [InlineData("a-b-c")]
+    [InlineData("tool2")]
+    [InlineData("123")]
+    public void ValidNames_Match(string name)
+    {
+        Assert.True(ValidPluginName.IsMatch(name), $"Expected '{name}' to be valid");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("-foo")]           // leading hyphen
+    [InlineData("foo-")]           // trailing hyphen
+    [InlineData("-")]              // just a hyphen
+    [InlineData("Foo")]            // uppercase
+    [InlineData("My-Tool")]        // mixed case
+    [InlineData("foo bar")]        // space
+    [InlineData("foo_bar")]        // underscore
+    [InlineData("foo.bar")]        // dot
+    [InlineData("foo/bar")]        // slash
+    [InlineData("foo\\bar")]       // backslash
+    public void InvalidNames_DoNotMatch(string name)
+    {
+        Assert.False(ValidPluginName.IsMatch(name), $"Expected '{name}' to be invalid");
+    }
+
+    [Fact]
+    public void SingleCharacterName_Valid()
+    {
+        Assert.Matches(ValidPluginName, "x");
+        Assert.Matches(ValidPluginName, "0");
+    }
+
+    [Fact]
+    public void TwoCharacterName_Valid()
+    {
+        Assert.Matches(ValidPluginName, "ab");
+        Assert.Matches(ValidPluginName, "a1");
+    }
+}

--- a/UnityCtl.Tests/Unit/Cli/PluginPathTraversalTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/PluginPathTraversalTests.cs
@@ -46,11 +46,17 @@ public class PluginPathTraversalTests : IDisposable
     [Theory]
     [InlineData("../../secret.cs")]
     [InlineData("../secret.cs")]
-    [InlineData("..\\..\\secret.cs")]
     [InlineData("subdir/../../secret.cs")]
     public void TraversalPaths_Rejected(string handlerFile)
     {
         Assert.False(PluginLoader.IsPathWithin(_pluginDir, handlerFile));
+    }
+
+    [SkippableFact]
+    public void BackslashTraversal_OnWindows_Rejected()
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+        Assert.False(PluginLoader.IsPathWithin(_pluginDir, "..\\..\\secret.cs"));
     }
 
     [Fact]

--- a/UnityCtl.Tests/Unit/Cli/PluginPathTraversalTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/PluginPathTraversalTests.cs
@@ -1,14 +1,14 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using UnityCtl.Cli;
 using Xunit;
 
 namespace UnityCtl.Tests.Unit.Cli;
 
 /// <summary>
-/// Tests the path traversal guard used in PluginLoader.ExecutePluginCommandAsync
-/// and PluginLoader.GenerateSkillSection. Verifies that handler file paths
-/// cannot escape the plugin directory.
+/// Tests PluginLoader.IsPathWithin, which guards against path traversal
+/// in plugin handler file references.
 /// </summary>
 public class PluginPathTraversalTests : IDisposable
 {
@@ -35,25 +35,12 @@ public class PluginPathTraversalTests : IDisposable
         try { Directory.Delete(_tempDir, recursive: true); } catch { }
     }
 
-    /// <summary>
-    /// Replicates the path traversal check from PluginLoader.ExecutePluginCommandAsync.
-    /// </summary>
-    private static bool IsPathWithinPluginDir(string pluginDir, string handlerFile)
-    {
-        var scriptPath = Path.GetFullPath(Path.Combine(pluginDir, handlerFile));
-        var resolvedPluginDir = Path.GetFullPath(pluginDir) + Path.DirectorySeparatorChar;
-        var pathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-        return scriptPath.StartsWith(resolvedPluginDir, pathComparison);
-    }
-
     [Theory]
     [InlineData("handler.cs")]
     [InlineData("subdir/nested.cs")]
     public void ValidHandlerPaths_Allowed(string handlerFile)
     {
-        Assert.True(IsPathWithinPluginDir(_pluginDir, handlerFile));
+        Assert.True(PluginLoader.IsPathWithin(_pluginDir, handlerFile));
     }
 
     [Theory]
@@ -63,63 +50,48 @@ public class PluginPathTraversalTests : IDisposable
     [InlineData("subdir/../../secret.cs")]
     public void TraversalPaths_Rejected(string handlerFile)
     {
-        Assert.False(IsPathWithinPluginDir(_pluginDir, handlerFile));
+        Assert.False(PluginLoader.IsPathWithin(_pluginDir, handlerFile));
     }
 
     [Fact]
     public void AbsolutePath_OutsidePluginDir_Rejected()
     {
-        // An absolute path to a file outside the plugin dir
         var absolutePath = Path.Combine(_tempDir, "secret.cs");
-        Assert.False(IsPathWithinPluginDir(_pluginDir, absolutePath));
+        Assert.False(PluginLoader.IsPathWithin(_pluginDir, absolutePath));
     }
 
     [Fact]
     public void AbsolutePath_InsidePluginDir_Allowed()
     {
         var absolutePath = Path.Combine(_pluginDir, "handler.cs");
-        Assert.True(IsPathWithinPluginDir(_pluginDir, absolutePath));
+        Assert.True(PluginLoader.IsPathWithin(_pluginDir, absolutePath));
     }
 
     [Fact]
     public void PluginDirWithTrailingSlash_TraversalStillRejected()
     {
-        // Even if the plugin dir already has a trailing separator, traversal should be caught
         var dirWithSlash = _pluginDir + Path.DirectorySeparatorChar;
-        Assert.False(IsPathWithinPluginDir(dirWithSlash, "../../secret.cs"));
+        Assert.False(PluginLoader.IsPathWithin(dirWithSlash, "../../secret.cs"));
     }
 
     [Fact]
     public void PluginDirWithTrailingSlash_ValidFile_Allowed()
     {
-        // Path.GetFullPath normalizes double separators, so this should work
-        // Note: GetFullPath(dir + "/" + "handler.cs") normalizes the double-separator
         var dirWithSlash = _pluginDir + Path.DirectorySeparatorChar;
-        var scriptPath = Path.GetFullPath(Path.Combine(dirWithSlash, "handler.cs"));
-        var resolvedDir = Path.GetFullPath(dirWithSlash) + Path.DirectorySeparatorChar;
-
-        // The resolved dir gets a double separator which GetFullPath normalizes differently.
-        // The production code uses Path.GetFullPath(pluginDir) + separator, which handles this
-        // because GetFullPath strips the trailing separator before re-adding it.
-        var normalizedDir = Path.GetFullPath(_pluginDir) + Path.DirectorySeparatorChar;
-        Assert.StartsWith(normalizedDir, scriptPath);
+        Assert.True(PluginLoader.IsPathWithin(dirWithSlash, "handler.cs"));
     }
 
     [SkippableFact]
     public void CaseVariation_OnWindows_StillRejected()
     {
         Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-
-        // On Windows, "../SECRET.CS" with different casing should still be rejected
-        Assert.False(IsPathWithinPluginDir(_pluginDir, "..\\..\\SECRET.CS"));
+        Assert.False(PluginLoader.IsPathWithin(_pluginDir, "..\\..\\SECRET.CS"));
     }
 
     [SkippableFact]
     public void CaseVariation_OnWindows_InsideDir_Allowed()
     {
         Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-
-        // On Windows, case shouldn't matter for files inside the dir
-        Assert.True(IsPathWithinPluginDir(_pluginDir, "HANDLER.CS"));
+        Assert.True(PluginLoader.IsPathWithin(_pluginDir, "HANDLER.CS"));
     }
 }

--- a/UnityCtl.Tests/Unit/Cli/PluginPathTraversalTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/PluginPathTraversalTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace UnityCtl.Tests.Unit.Cli;
+
+/// <summary>
+/// Tests the path traversal guard used in PluginLoader.ExecutePluginCommandAsync
+/// and PluginLoader.GenerateSkillSection. Verifies that handler file paths
+/// cannot escape the plugin directory.
+/// </summary>
+public class PluginPathTraversalTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _pluginDir;
+
+    public PluginPathTraversalTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"unityctl-test-{Guid.NewGuid():N}");
+        _pluginDir = Path.Combine(_tempDir, "plugins", "my-plugin");
+        Directory.CreateDirectory(_pluginDir);
+
+        // Create a handler file inside the plugin directory
+        File.WriteAllText(Path.Combine(_pluginDir, "handler.cs"), "// test");
+        Directory.CreateDirectory(Path.Combine(_pluginDir, "subdir"));
+        File.WriteAllText(Path.Combine(_pluginDir, "subdir", "nested.cs"), "// test");
+
+        // Create a file outside the plugin directory (the attacker's target)
+        File.WriteAllText(Path.Combine(_tempDir, "secret.cs"), "// secret");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// Replicates the path traversal check from PluginLoader.ExecutePluginCommandAsync.
+    /// </summary>
+    private static bool IsPathWithinPluginDir(string pluginDir, string handlerFile)
+    {
+        var scriptPath = Path.GetFullPath(Path.Combine(pluginDir, handlerFile));
+        var resolvedPluginDir = Path.GetFullPath(pluginDir) + Path.DirectorySeparatorChar;
+        var pathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return scriptPath.StartsWith(resolvedPluginDir, pathComparison);
+    }
+
+    [Theory]
+    [InlineData("handler.cs")]
+    [InlineData("subdir/nested.cs")]
+    public void ValidHandlerPaths_Allowed(string handlerFile)
+    {
+        Assert.True(IsPathWithinPluginDir(_pluginDir, handlerFile));
+    }
+
+    [Theory]
+    [InlineData("../../secret.cs")]
+    [InlineData("../secret.cs")]
+    [InlineData("..\\..\\secret.cs")]
+    [InlineData("subdir/../../secret.cs")]
+    public void TraversalPaths_Rejected(string handlerFile)
+    {
+        Assert.False(IsPathWithinPluginDir(_pluginDir, handlerFile));
+    }
+
+    [Fact]
+    public void AbsolutePath_OutsidePluginDir_Rejected()
+    {
+        // An absolute path to a file outside the plugin dir
+        var absolutePath = Path.Combine(_tempDir, "secret.cs");
+        Assert.False(IsPathWithinPluginDir(_pluginDir, absolutePath));
+    }
+
+    [Fact]
+    public void AbsolutePath_InsidePluginDir_Allowed()
+    {
+        var absolutePath = Path.Combine(_pluginDir, "handler.cs");
+        Assert.True(IsPathWithinPluginDir(_pluginDir, absolutePath));
+    }
+
+    [Fact]
+    public void PluginDirWithTrailingSlash_TraversalStillRejected()
+    {
+        // Even if the plugin dir already has a trailing separator, traversal should be caught
+        var dirWithSlash = _pluginDir + Path.DirectorySeparatorChar;
+        Assert.False(IsPathWithinPluginDir(dirWithSlash, "../../secret.cs"));
+    }
+
+    [Fact]
+    public void PluginDirWithTrailingSlash_ValidFile_Allowed()
+    {
+        // Path.GetFullPath normalizes double separators, so this should work
+        // Note: GetFullPath(dir + "/" + "handler.cs") normalizes the double-separator
+        var dirWithSlash = _pluginDir + Path.DirectorySeparatorChar;
+        var scriptPath = Path.GetFullPath(Path.Combine(dirWithSlash, "handler.cs"));
+        var resolvedDir = Path.GetFullPath(dirWithSlash) + Path.DirectorySeparatorChar;
+
+        // The resolved dir gets a double separator which GetFullPath normalizes differently.
+        // The production code uses Path.GetFullPath(pluginDir) + separator, which handles this
+        // because GetFullPath strips the trailing separator before re-adding it.
+        var normalizedDir = Path.GetFullPath(_pluginDir) + Path.DirectorySeparatorChar;
+        Assert.StartsWith(normalizedDir, scriptPath);
+    }
+
+    [SkippableFact]
+    public void CaseVariation_OnWindows_StillRejected()
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
+        // On Windows, "../SECRET.CS" with different casing should still be rejected
+        Assert.False(IsPathWithinPluginDir(_pluginDir, "..\\..\\SECRET.CS"));
+    }
+
+    [SkippableFact]
+    public void CaseVariation_OnWindows_InsideDir_Allowed()
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
+        // On Windows, case shouldn't matter for files inside the dir
+        Assert.True(IsPathWithinPluginDir(_pluginDir, "HANDLER.CS"));
+    }
+}

--- a/UnityCtl.Tests/Unit/Cli/PluginSkillGenerationTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/PluginSkillGenerationTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.IO;
+using UnityCtl.Cli;
+using Xunit;
+
+namespace UnityCtl.Tests.Unit.Cli;
+
+public class PluginSkillGenerationTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public PluginSkillGenerationTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"unityctl-skill-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void GenerateSkillSection_WithCommands_ProducesMarkdown()
+    {
+        var plugin = new LoadedPlugin
+        {
+            Manifest = new PluginManifest
+            {
+                Name = "my-tool",
+                Description = "A useful tool",
+                Commands = new[]
+                {
+                    new PluginCommandDefinition
+                    {
+                        Name = "run",
+                        Description = "Run the tool",
+                        Arguments = new[]
+                        {
+                            new PluginArgumentDefinition { Name = "target", Required = true },
+                            new PluginArgumentDefinition { Name = "extra", Required = false }
+                        },
+                        Options = new[]
+                        {
+                            new PluginOptionDefinition { Name = "verbose", Type = "bool", Description = "Verbose" },
+                            new PluginOptionDefinition { Name = "format", Type = "string", Description = "Format" }
+                        },
+                        Handler = new PluginHandler { File = "run.cs" }
+                    }
+                }
+            },
+            Directory = _tempDir,
+            Source = "project"
+        };
+
+        var section = PluginLoader.GenerateSkillSection(plugin);
+
+        Assert.Contains("### Plugin: my-tool", section);
+        Assert.Contains("A useful tool", section);
+        Assert.Contains("`unityctl my-tool run <target> [extra] [--verbose] [--format <value>]`", section);
+        Assert.Contains("Run the tool", section);
+    }
+
+    [Fact]
+    public void GenerateSkillSection_NoDescription_OmitsDescriptionLine()
+    {
+        var plugin = new LoadedPlugin
+        {
+            Manifest = new PluginManifest
+            {
+                Name = "bare",
+                Commands = new[]
+                {
+                    new PluginCommandDefinition
+                    {
+                        Name = "do",
+                        Handler = new PluginHandler { File = "do.cs" }
+                    }
+                }
+            },
+            Directory = _tempDir,
+            Source = "project"
+        };
+
+        var section = PluginLoader.GenerateSkillSection(plugin);
+
+        Assert.Contains("### Plugin: bare", section);
+        Assert.Contains("`unityctl bare do`", section);
+    }
+
+    [Fact]
+    public void GenerateSkillSection_CustomSkillFile_ReadsFromFile()
+    {
+        var customContent = "### My Custom Skill Section\n\nCustom docs here.";
+        File.WriteAllText(Path.Combine(_tempDir, "MY-SKILL.md"), customContent);
+
+        var plugin = new LoadedPlugin
+        {
+            Manifest = new PluginManifest
+            {
+                Name = "custom",
+                Skill = new PluginSkillSection { File = "MY-SKILL.md" },
+                Commands = new[]
+                {
+                    new PluginCommandDefinition
+                    {
+                        Name = "unused",
+                        Handler = new PluginHandler { File = "unused.cs" }
+                    }
+                }
+            },
+            Directory = _tempDir,
+            Source = "project"
+        };
+
+        var section = PluginLoader.GenerateSkillSection(plugin);
+
+        Assert.Equal(customContent, section);
+    }
+
+    [Fact]
+    public void GenerateSkillSection_CustomSkillFile_TraversalPath_FallsBackToAutoGenerate()
+    {
+        // If the skill file path escapes the plugin dir, it should fall back to auto-generation
+        var plugin = new LoadedPlugin
+        {
+            Manifest = new PluginManifest
+            {
+                Name = "sneaky",
+                Description = "Auto-generated fallback",
+                Skill = new PluginSkillSection { File = "../../etc/passwd" },
+                Commands = new[]
+                {
+                    new PluginCommandDefinition
+                    {
+                        Name = "cmd",
+                        Handler = new PluginHandler { File = "cmd.cs" }
+                    }
+                }
+            },
+            Directory = _tempDir,
+            Source = "project"
+        };
+
+        var section = PluginLoader.GenerateSkillSection(plugin);
+
+        // Should auto-generate, not read the traversal path
+        Assert.Contains("### Plugin: sneaky", section);
+        Assert.Contains("Auto-generated fallback", section);
+    }
+
+    [Fact]
+    public void GenerateSkillSection_OptionWithDashPrefix_NotDoubled()
+    {
+        var plugin = new LoadedPlugin
+        {
+            Manifest = new PluginManifest
+            {
+                Name = "opt-test",
+                Commands = new[]
+                {
+                    new PluginCommandDefinition
+                    {
+                        Name = "cmd",
+                        Options = new[]
+                        {
+                            new PluginOptionDefinition { Name = "--already-prefixed", Type = "string" }
+                        },
+                        Handler = new PluginHandler { File = "cmd.cs" }
+                    }
+                }
+            },
+            Directory = _tempDir,
+            Source = "project"
+        };
+
+        var section = PluginLoader.GenerateSkillSection(plugin);
+
+        // Should not produce "----already-prefixed"
+        Assert.Contains("[--already-prefixed <value>]", section);
+        Assert.DoesNotContain("----", section);
+    }
+
+    [Fact]
+    public void ExecutablePlugin_GetSkillSection_WithCompanionFile_ReadsFile()
+    {
+        var companionContent = "### Plugin: my-exec\n\nCustom executable docs.";
+        File.WriteAllText(Path.Combine(_tempDir, "unityctl-my-exec.skill.md"), companionContent);
+
+        var plugin = new ExecutablePlugin
+        {
+            Name = "my-exec",
+            Path = Path.Combine(_tempDir, "unityctl-my-exec.exe"),
+            Source = "project"
+        };
+
+        var section = ExecutablePluginLoader.GetSkillSection(plugin);
+
+        Assert.Equal(companionContent, section);
+    }
+
+    [Fact]
+    public void ExecutablePlugin_GetSkillSection_NoCompanionFile_AutoGenerates()
+    {
+        var plugin = new ExecutablePlugin
+        {
+            Name = "my-exec",
+            Path = Path.Combine(_tempDir, "unityctl-my-exec.exe"),
+            Source = "project",
+            Description = "Does stuff"
+        };
+
+        var section = ExecutablePluginLoader.GetSkillSection(plugin);
+
+        Assert.NotNull(section);
+        Assert.Contains("### Plugin: my-exec (executable)", section!);
+        Assert.Contains("Does stuff", section);
+        Assert.Contains("`unityctl my-exec [args...]`", section);
+    }
+}

--- a/UnityCtl.Tests/UnityCtl.Tests.csproj
+++ b/UnityCtl.Tests/UnityCtl.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adds a plugin system that lets users extend `unityctl` with custom commands — no changes to the bridge or Unity plugin required.

Two plugin types:

- **Script plugins** — C# scripts executed inside Unity via the existing `script.execute` RPC. Best for commands that need Unity APIs (scene queries, asset manipulation, etc.).
- **Executable plugins** — any `unityctl-<name>` binary/script on disk, following the git/kubectl naming convention. Best for orchestration, CI pipelines, and workflows outside Unity.

## How it works

### Script plugins

A `plugin.json` manifest declares commands with typed arguments, options, and a C# handler script. The handler runs on Unity's main thread with full access to UnityEngine/UnityEditor APIs.

```
.unityctl/plugins/scene-stats/
  plugin.json       # manifest: commands, args, options, handler mapping
  stats.cs          # C# script executed in Unity
  SKILL-SECTION.md  # optional custom AI documentation
```

```bash
# Scaffold a new plugin
unityctl plugin create scene-stats

# Use it (dispatches to Unity via bridge)
unityctl scene-stats stats --verbose
unityctl scene-stats stats MainScene --format json
```

### Executable plugins

Place any executable named `unityctl-<name>` in `.unityctl/plugins/` or on PATH. All arguments are passed through; bridge connection info is injected via environment variables (`UNITYCTL_BRIDGE_URL`, `UNITYCTL_PROJECT_PATH`, etc.).

```bash
# A bash script saved as .unityctl/plugins/unityctl-smoke
unityctl smoke 30          # runs unityctl-smoke with arg "30"
unityctl deploy --staging  # runs unityctl-deploy with arg "--staging"
```

Executables in plugin directories appear in `--help` at startup. PATH executables are resolved lazily at invocation time (git-style fallback).

### Plugin locations

| Level | Directory | Precedence |
|-------|-----------|------------|
| Project | `.unityctl/plugins/` | Higher (shareable via git) |
| User | `~/.unityctl/plugins/` | Lower (personal tools) |

### Skill composition

Plugins can provide AI documentation via custom `SKILL-SECTION.md` files or auto-generated docs from the manifest. The new `skill rebuild` command composes the final SKILL.md from:

1. Base embedded skill (source of truth in `UnityCtl.Cli/Resources/SKILL.md`)
2. Auto-generated plugin command sections
3. Optional user-provided `.unityctl/skill-extra.md`

## Design decisions

- **Zero bridge/Unity changes** — script plugins reuse `script.execute` RPC; executable plugins are spawned as child processes
- **Precedence**: built-in > script plugin > executable plugin; project-level > user-level > PATH
- **Security**: handler file paths validated against path traversal; plugins that conflict with built-in command names are skipped with a warning
- **Idempotent**: with no plugins and no `skill-extra.md`, behavior is identical to before

## Management commands

```bash
unityctl plugin list              # list all discovered plugins (script + executable)
unityctl plugin create <name>     # scaffold a script plugin (project-level)
unityctl plugin create <name> -g  # scaffold at user level (~/.unityctl/plugins/)
unityctl plugin remove <name>     # remove a script plugin
unityctl skill rebuild            # recompose SKILL.md with plugin docs
```

## New files

| File | Purpose |
|------|---------|
| `PluginManifest.cs` | Plugin manifest model (`plugin.json` schema) |
| `PluginLoader.cs` | Discovers script plugins, creates System.CommandLine commands, generates skill sections |
| `PluginCommands.cs` | `plugin list/create/remove` management commands |
| `ExecutablePluginLoader.cs` | Discovers executable plugins, PATH fallback, process spawning with env vars |
| `ContextHelper.cs` | Shared helpers for extracting global options from `InvocationContext` |
| `Resources/SKILL.md` | Base skill (embedded resource, source of truth) |
| `Resources/SKILL.plugins.md` | Claude Code skill for plugin authoring guidance |
| `.unityctl/plugins/sample-*` | Sample plugins demonstrating both types |

## Test plan
- [x] `dotnet build` succeeds
- [x] All 261 existing tests pass
- [x] `plugin create` scaffolds valid plugin with manifest + example script
- [x] `plugin list` discovers and displays plugins from both sources (script + executable)
- [x] Dynamic plugin commands appear in `--help` and accept declared args/options
- [x] `plugin remove` cleans up plugin directory
- [x] `skill rebuild` produces composed SKILL.md with plugin sections appended
- [x] JSON output mode works for all new commands
- [x] Plugin with name matching built-in command is skipped gracefully
- [ ] End-to-end: plugin command executes script in Unity via bridge
- [ ] End-to-end: executable plugin receives env vars and passes exit code through