### PR TITLE
Make script eval/execute async by default

### DIFF
--- a/.claude/skills/unity-editor/SKILL.md
+++ b/.claude/skills/unity-editor/SKILL.md
@@ -173,17 +173,15 @@ For complex scripts with custom classes, multiple methods, or logic beyond a sin
 
 ```cs
 // /tmp/MyScript.cs
-using System.Threading.Tasks;
 using UnityEngine;
 
 public class Script
 {
-    // Sync: return a JSON-serializable value.
-    public static object Main() =>
-        GameObject.Find("Player")?.transform.position.ToString() ?? "not found";
-
-    // Or async: return Task<T> for a value, or Task for side-effect-only.
-    // public static async Task<int> Main() { await Task.Delay(100); return 42; }
+    public static object Main()
+    {
+        var player = GameObject.Find("Player");
+        return player?.transform.position.ToString() ?? "not found";
+    }
 }
 ```
 

--- a/.claude/skills/unity-editor/SKILL.md
+++ b/.claude/skills/unity-editor/SKILL.md
@@ -149,26 +149,23 @@ Pass arguments to the script with `--`:
 unityctl script eval 'args[0]' -- hello
 ```
 
-### Async / waiting on things
+### Async / waiting
 
-`script eval` and `script execute` are **async by default**. Write `await` directly (`System.Threading.Tasks` is in the default usings):
+Eval is `async` by default — use `await` directly. `System.Threading.Tasks` is in default usings:
 
 ```bash
 unityctl script eval 'await Task.Delay(500); return GameObject.Find("Boss") != null;'
 ```
 
-While your script awaits, Unity's main thread is freed — other unityctl commands keep running. `Task<T>` returns are unwrapped automatically (you get `T`, not the Task envelope).
+`Task<T>` returns are unwrapped — `return Task.FromResult(x)` gives you `x`, not the envelope.
 
-| If you want to … | Write |
-|---|---|
-| Pause a moment | `await Task.Delay(ms);` |
-| Yield once (let Unity tick) | `await Task.Yield();` |
-| Poll until a condition | `while (!cond) await Task.Yield();` |
-| Run pure CPU off the main thread | `await Task.Run(() => heavy())` |
+Unity's `AsyncOperation` (scene loads, asset ops, web requests) isn't a `Task` — bridge it:
 
-**Threading rule:** Unity APIs (`GameObject.Find`, `Application.isPlaying`, anything in `UnityEngine`/`UnityEditor`) are **main-thread only**. Don't put them inside `Task.Run` — they'll throw. Plain C# (LINQ over plain data, math, I/O) is fine on the threadpool.
+```cs
+var tcs = new TaskCompletionSource<bool>(); op.completed += _ => tcs.SetResult(true); await tcs.Task;
+```
 
-**Avoid:** `Task.Wait()` and `.Result` on tasks whose continuations need the main thread (i.e. anything calling Unity APIs after the await). Use `await` instead — it doesn't block the main thread and won't deadlock the editor.
+Unity APIs (`UnityEngine.*`, `UnityEditor.*`) are main-thread only — calling them inside `Task.Run` throws. Don't `.Wait()` or `.Result` an awaited task; it can deadlock the editor. Use `await`.
 
 ### Full Script Execution
 

--- a/.claude/skills/unity-editor/SKILL.md
+++ b/.claude/skills/unity-editor/SKILL.md
@@ -149,21 +149,44 @@ Pass arguments to the script with `--`:
 unityctl script eval 'args[0]' -- hello
 ```
 
+### Async / waiting on things
+
+`script eval` and `script execute` are **async by default**. Write `await` directly:
+
+```bash
+unityctl script eval 'await System.Threading.Tasks.Task.Delay(500); return GameObject.Find("Boss") != null;'
+```
+
+While your script awaits, Unity's main thread is freed — other unityctl commands keep running. `Task<T>` returns are unwrapped automatically (you get `T`, not the Task envelope).
+
+| If you want to … | Write |
+|---|---|
+| Pause a moment | `await System.Threading.Tasks.Task.Delay(ms);` |
+| Yield once (let Unity tick) | `await System.Threading.Tasks.Task.Yield();` |
+| Poll until a condition | `while (!cond) await System.Threading.Tasks.Task.Yield();` |
+| Run pure CPU off the main thread | `await System.Threading.Tasks.Task.Run(() => heavy())` |
+
+**Threading rule:** Unity APIs (`GameObject.Find`, `Application.isPlaying`, anything in `UnityEngine`/`UnityEditor`) are **main-thread only**. Don't put them inside `Task.Run` — they'll throw. Plain C# (LINQ over plain data, math, I/O) is fine on the threadpool.
+
+**Avoid:** `Task.Wait()` and `.Result` on tasks whose continuations need the main thread (i.e. anything calling Unity APIs after the await). Use `await` instead — it doesn't block the main thread and won't deadlock the editor.
+
 ### Full Script Execution
 
-For complex scripts with custom classes, multiple methods, or logic beyond a single expression. Use the Write tool to create a `.cs` file, then execute it. The script must define a class with a static `Main()` method returning `object` (JSON-serialized):
+For complex scripts with custom classes, multiple methods, or logic beyond a single expression. Use the Write tool to create a `.cs` file, then execute it. Define a class with a static `Main()` method — sync, async `Task<T>`, or async `Task`:
 
 ```cs
 // /tmp/MyScript.cs
+using System.Threading.Tasks;
 using UnityEngine;
 
 public class Script
 {
-    public static object Main()
-    {
-        var player = GameObject.Find("Player");
-        return player?.transform.position.ToString() ?? "not found";
-    }
+    // Sync: return a JSON-serializable value.
+    public static object Main() =>
+        GameObject.Find("Player")?.transform.position.ToString() ?? "not found";
+
+    // Or async: return Task<T> for a value, or Task for side-effect-only.
+    // public static async Task<int> Main() { await Task.Delay(100); return 42; }
 }
 ```
 

--- a/.claude/skills/unity-editor/SKILL.md
+++ b/.claude/skills/unity-editor/SKILL.md
@@ -151,20 +151,20 @@ unityctl script eval 'args[0]' -- hello
 
 ### Async / waiting on things
 
-`script eval` and `script execute` are **async by default**. Write `await` directly:
+`script eval` and `script execute` are **async by default**. Write `await` directly (`System.Threading.Tasks` is in the default usings):
 
 ```bash
-unityctl script eval 'await System.Threading.Tasks.Task.Delay(500); return GameObject.Find("Boss") != null;'
+unityctl script eval 'await Task.Delay(500); return GameObject.Find("Boss") != null;'
 ```
 
 While your script awaits, Unity's main thread is freed — other unityctl commands keep running. `Task<T>` returns are unwrapped automatically (you get `T`, not the Task envelope).
 
 | If you want to … | Write |
 |---|---|
-| Pause a moment | `await System.Threading.Tasks.Task.Delay(ms);` |
-| Yield once (let Unity tick) | `await System.Threading.Tasks.Task.Yield();` |
-| Poll until a condition | `while (!cond) await System.Threading.Tasks.Task.Yield();` |
-| Run pure CPU off the main thread | `await System.Threading.Tasks.Task.Run(() => heavy())` |
+| Pause a moment | `await Task.Delay(ms);` |
+| Yield once (let Unity tick) | `await Task.Yield();` |
+| Poll until a condition | `while (!cond) await Task.Yield();` |
+| Run pure CPU off the main thread | `await Task.Run(() => heavy())` |
 
 **Threading rule:** Unity APIs (`GameObject.Find`, `Application.isPlaying`, anything in `UnityEngine`/`UnityEditor`) are **main-thread only**. Don't put them inside `Task.Run` — they'll throw. Plain C# (LINQ over plain data, math, I/O) is fine on the threadpool.
 

--- a/.claude/skills/unity-editor/SKILL.md
+++ b/.claude/skills/unity-editor/SKILL.md
@@ -159,14 +159,6 @@ unityctl script eval 'await Task.Delay(500); return GameObject.Find("Boss") != n
 
 `Task<T>` returns are unwrapped — `return Task.FromResult(x)` gives you `x`, not the envelope.
 
-Unity's `AsyncOperation` (scene loads, asset ops, web requests) isn't a `Task` — bridge it:
-
-```cs
-var tcs = new TaskCompletionSource<bool>(); op.completed += _ => tcs.SetResult(true); await tcs.Task;
-```
-
-Unity APIs (`UnityEngine.*`, `UnityEditor.*`) are main-thread only — calling them inside `Task.Run` throws. Don't `.Wait()` or `.Result` an awaited task; it can deadlock the editor. Use `await`.
-
 ### Full Script Execution
 
 For complex scripts with custom classes, multiple methods, or logic beyond a single expression. Use the Write tool to create a `.cs` file, then execute it. Define a class with a static `Main()` method — sync, async `Task<T>`, or async `Task`:

--- a/UnityCtl.Cli/Resources/SKILL.md
+++ b/UnityCtl.Cli/Resources/SKILL.md
@@ -173,17 +173,15 @@ For complex scripts with custom classes, multiple methods, or logic beyond a sin
 
 ```cs
 // /tmp/MyScript.cs
-using System.Threading.Tasks;
 using UnityEngine;
 
 public class Script
 {
-    // Sync: return a JSON-serializable value.
-    public static object Main() =>
-        GameObject.Find("Player")?.transform.position.ToString() ?? "not found";
-
-    // Or async: return Task<T> for a value, or Task for side-effect-only.
-    // public static async Task<int> Main() { await Task.Delay(100); return 42; }
+    public static object Main()
+    {
+        var player = GameObject.Find("Player");
+        return player?.transform.position.ToString() ?? "not found";
+    }
 }
 ```
 

--- a/UnityCtl.Cli/Resources/SKILL.md
+++ b/UnityCtl.Cli/Resources/SKILL.md
@@ -149,26 +149,23 @@ Pass arguments to the script with `--`:
 unityctl script eval 'args[0]' -- hello
 ```
 
-### Async / waiting on things
+### Async / waiting
 
-`script eval` and `script execute` are **async by default**. Write `await` directly (`System.Threading.Tasks` is in the default usings):
+Eval is `async` by default — use `await` directly. `System.Threading.Tasks` is in default usings:
 
 ```bash
 unityctl script eval 'await Task.Delay(500); return GameObject.Find("Boss") != null;'
 ```
 
-While your script awaits, Unity's main thread is freed — other unityctl commands keep running. `Task<T>` returns are unwrapped automatically (you get `T`, not the Task envelope).
+`Task<T>` returns are unwrapped — `return Task.FromResult(x)` gives you `x`, not the envelope.
 
-| If you want to … | Write |
-|---|---|
-| Pause a moment | `await Task.Delay(ms);` |
-| Yield once (let Unity tick) | `await Task.Yield();` |
-| Poll until a condition | `while (!cond) await Task.Yield();` |
-| Run pure CPU off the main thread | `await Task.Run(() => heavy())` |
+Unity's `AsyncOperation` (scene loads, asset ops, web requests) isn't a `Task` — bridge it:
 
-**Threading rule:** Unity APIs (`GameObject.Find`, `Application.isPlaying`, anything in `UnityEngine`/`UnityEditor`) are **main-thread only**. Don't put them inside `Task.Run` — they'll throw. Plain C# (LINQ over plain data, math, I/O) is fine on the threadpool.
+```cs
+var tcs = new TaskCompletionSource<bool>(); op.completed += _ => tcs.SetResult(true); await tcs.Task;
+```
 
-**Avoid:** `Task.Wait()` and `.Result` on tasks whose continuations need the main thread (i.e. anything calling Unity APIs after the await). Use `await` instead — it doesn't block the main thread and won't deadlock the editor.
+Unity APIs (`UnityEngine.*`, `UnityEditor.*`) are main-thread only — calling them inside `Task.Run` throws. Don't `.Wait()` or `.Result` an awaited task; it can deadlock the editor. Use `await`.
 
 ### Full Script Execution
 

--- a/UnityCtl.Cli/Resources/SKILL.md
+++ b/UnityCtl.Cli/Resources/SKILL.md
@@ -149,21 +149,44 @@ Pass arguments to the script with `--`:
 unityctl script eval 'args[0]' -- hello
 ```
 
+### Async / waiting on things
+
+`script eval` and `script execute` are **async by default**. Write `await` directly:
+
+```bash
+unityctl script eval 'await System.Threading.Tasks.Task.Delay(500); return GameObject.Find("Boss") != null;'
+```
+
+While your script awaits, Unity's main thread is freed — other unityctl commands keep running. `Task<T>` returns are unwrapped automatically (you get `T`, not the Task envelope).
+
+| If you want to … | Write |
+|---|---|
+| Pause a moment | `await System.Threading.Tasks.Task.Delay(ms);` |
+| Yield once (let Unity tick) | `await System.Threading.Tasks.Task.Yield();` |
+| Poll until a condition | `while (!cond) await System.Threading.Tasks.Task.Yield();` |
+| Run pure CPU off the main thread | `await System.Threading.Tasks.Task.Run(() => heavy())` |
+
+**Threading rule:** Unity APIs (`GameObject.Find`, `Application.isPlaying`, anything in `UnityEngine`/`UnityEditor`) are **main-thread only**. Don't put them inside `Task.Run` — they'll throw. Plain C# (LINQ over plain data, math, I/O) is fine on the threadpool.
+
+**Avoid:** `Task.Wait()` and `.Result` on tasks whose continuations need the main thread (i.e. anything calling Unity APIs after the await). Use `await` instead — it doesn't block the main thread and won't deadlock the editor.
+
 ### Full Script Execution
 
-For complex scripts with custom classes, multiple methods, or logic beyond a single expression. Use the Write tool to create a `.cs` file, then execute it. The script must define a class with a static `Main()` method returning `object` (JSON-serialized):
+For complex scripts with custom classes, multiple methods, or logic beyond a single expression. Use the Write tool to create a `.cs` file, then execute it. Define a class with a static `Main()` method — sync, async `Task<T>`, or async `Task`:
 
 ```cs
 // /tmp/MyScript.cs
+using System.Threading.Tasks;
 using UnityEngine;
 
 public class Script
 {
-    public static object Main()
-    {
-        var player = GameObject.Find("Player");
-        return player?.transform.position.ToString() ?? "not found";
-    }
+    // Sync: return a JSON-serializable value.
+    public static object Main() =>
+        GameObject.Find("Player")?.transform.position.ToString() ?? "not found";
+
+    // Or async: return Task<T> for a value, or Task for side-effect-only.
+    // public static async Task<int> Main() { await Task.Delay(100); return 42; }
 }
 ```
 

--- a/UnityCtl.Cli/Resources/SKILL.md
+++ b/UnityCtl.Cli/Resources/SKILL.md
@@ -151,20 +151,20 @@ unityctl script eval 'args[0]' -- hello
 
 ### Async / waiting on things
 
-`script eval` and `script execute` are **async by default**. Write `await` directly:
+`script eval` and `script execute` are **async by default**. Write `await` directly (`System.Threading.Tasks` is in the default usings):
 
 ```bash
-unityctl script eval 'await System.Threading.Tasks.Task.Delay(500); return GameObject.Find("Boss") != null;'
+unityctl script eval 'await Task.Delay(500); return GameObject.Find("Boss") != null;'
 ```
 
 While your script awaits, Unity's main thread is freed — other unityctl commands keep running. `Task<T>` returns are unwrapped automatically (you get `T`, not the Task envelope).
 
 | If you want to … | Write |
 |---|---|
-| Pause a moment | `await System.Threading.Tasks.Task.Delay(ms);` |
-| Yield once (let Unity tick) | `await System.Threading.Tasks.Task.Yield();` |
-| Poll until a condition | `while (!cond) await System.Threading.Tasks.Task.Yield();` |
-| Run pure CPU off the main thread | `await System.Threading.Tasks.Task.Run(() => heavy())` |
+| Pause a moment | `await Task.Delay(ms);` |
+| Yield once (let Unity tick) | `await Task.Yield();` |
+| Poll until a condition | `while (!cond) await Task.Yield();` |
+| Run pure CPU off the main thread | `await Task.Run(() => heavy())` |
 
 **Threading rule:** Unity APIs (`GameObject.Find`, `Application.isPlaying`, anything in `UnityEngine`/`UnityEditor`) are **main-thread only**. Don't put them inside `Task.Run` — they'll throw. Plain C# (LINQ over plain data, math, I/O) is fine on the threadpool.
 

--- a/UnityCtl.Cli/Resources/SKILL.md
+++ b/UnityCtl.Cli/Resources/SKILL.md
@@ -159,14 +159,6 @@ unityctl script eval 'await Task.Delay(500); return GameObject.Find("Boss") != n
 
 `Task<T>` returns are unwrapped — `return Task.FromResult(x)` gives you `x`, not the envelope.
 
-Unity's `AsyncOperation` (scene loads, asset ops, web requests) isn't a `Task` — bridge it:
-
-```cs
-var tcs = new TaskCompletionSource<bool>(); op.completed += _ => tcs.SetResult(true); await tcs.Task;
-```
-
-Unity APIs (`UnityEngine.*`, `UnityEditor.*`) are main-thread only — calling them inside `Task.Run` throws. Don't `.Wait()` or `.Result` an awaited task; it can deadlock the editor. Use `await`.
-
 ### Full Script Execution
 
 For complex scripts with custom classes, multiple methods, or logic beyond a single expression. Use the Write tool to create a `.cs` file, then execute it. Define a class with a static `Main()` method — sync, async `Task<T>`, or async `Task`:

--- a/UnityCtl.Cli/ScriptCommands.cs
+++ b/UnityCtl.Cli/ScriptCommands.cs
@@ -463,7 +463,11 @@ public static class ScriptCommands
         // Alias `Object` to UnityEngine.Object so bare `Object.FindFirstObjectByType<T>()`
         // compiles — otherwise it's ambiguous between UnityEngine.Object and System.Object.
         usingBlock += "\nusing Object = UnityEngine.Object;";
-        var signature = hasArgs ? "public static object Main(string[] args)" : "public static object Main()";
+        // Async-by-default: agents can write `await ...` directly in the expression.
+        // ScriptExecutor unwraps the returned Task<object> before serialization.
+        var signature = hasArgs
+            ? "public static async System.Threading.Tasks.Task<object> Main(string[] args)"
+            : "public static async System.Threading.Tasks.Task<object> Main()";
 
         var body = BuildEvalBody(expression);
 

--- a/UnityCtl.Cli/ScriptCommands.cs
+++ b/UnityCtl.Cli/ScriptCommands.cs
@@ -20,6 +20,7 @@ public static class ScriptCommands
         "System",
         "System.Collections.Generic",
         "System.Linq",
+        "System.Threading.Tasks",
         "UnityEngine",
         "UnityEditor"
     ];

--- a/UnityCtl.Cli/ScriptCommands.cs
+++ b/UnityCtl.Cli/ScriptCommands.cs
@@ -467,8 +467,8 @@ public static class ScriptCommands
         // Async-by-default: agents can write `await ...` directly in the expression.
         // ScriptExecutor unwraps the returned Task<object> before serialization.
         var signature = hasArgs
-            ? "public static async System.Threading.Tasks.Task<object> Main(string[] args)"
-            : "public static async System.Threading.Tasks.Task<object> Main()";
+            ? "public static async Task<object> Main(string[] args)"
+            : "public static async Task<object> Main()";
 
         var body = BuildEvalBody(expression);
 

--- a/UnityCtl.Tests/Unit/Cli/EvalCodeGeneratorTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/EvalCodeGeneratorTests.cs
@@ -31,6 +31,9 @@ public class EvalCodeGeneratorTests
         Assert.Contains("using System;", code);
         Assert.Contains("using System.Collections.Generic;", code);
         Assert.Contains("using System.Linq;", code);
+        // Async-by-default: agents write `Task.Delay(...)`, not the
+        // fully-qualified form, so System.Threading.Tasks is in defaults.
+        Assert.Contains("using System.Threading.Tasks;", code);
         Assert.Contains("using UnityEngine;", code);
         Assert.Contains("using UnityEditor;", code);
     }

--- a/UnityCtl.Tests/Unit/Cli/EvalCodeGeneratorTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/EvalCodeGeneratorTests.cs
@@ -63,7 +63,7 @@ public class EvalCodeGeneratorTests
         var code = ScriptCommands.BuildEvalCode("args[0]", [], hasArgs: true);
 
         // Async-by-default: agents can write `await ...` directly in eval.
-        Assert.Contains("public static async System.Threading.Tasks.Task<object> Main(string[] args)", code);
+        Assert.Contains("public static async Task<object> Main(string[] args)", code);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class EvalCodeGeneratorTests
     {
         var code = ScriptCommands.BuildEvalCode("1", [], hasArgs: false);
 
-        Assert.Contains("public static async System.Threading.Tasks.Task<object> Main()", code);
+        Assert.Contains("public static async Task<object> Main()", code);
         Assert.DoesNotContain("string[] args", code);
     }
 
@@ -81,7 +81,7 @@ public class EvalCodeGeneratorTests
         var code = ScriptCommands.BuildEvalCode("Application.version", [], hasArgs: false);
 
         Assert.Contains("public class Script", code);
-        Assert.Contains("public static async System.Threading.Tasks.Task<object> Main()", code);
+        Assert.Contains("public static async Task<object> Main()", code);
     }
 
     [Fact]
@@ -91,10 +91,10 @@ public class EvalCodeGeneratorTests
         // inside an async method so the `await` compiles. Before this change,
         // bare `await` produced CS4032.
         var code = ScriptCommands.BuildEvalCode(
-            "await System.Threading.Tasks.Task.Delay(10); return 42;", [], hasArgs: false);
+            "await Task.Delay(10); return 42;", [], hasArgs: false);
 
-        Assert.Contains("async System.Threading.Tasks.Task<object> Main", code);
-        Assert.Contains("await System.Threading.Tasks.Task.Delay(10);", code);
+        Assert.Contains("async Task<object> Main", code);
+        Assert.Contains("await Task.Delay(10);", code);
     }
 
     [Fact]

--- a/UnityCtl.Tests/Unit/Cli/EvalCodeGeneratorTests.cs
+++ b/UnityCtl.Tests/Unit/Cli/EvalCodeGeneratorTests.cs
@@ -55,19 +55,20 @@ public class EvalCodeGeneratorTests
     }
 
     [Fact]
-    public void WithArgs_UsesArgsSignature()
+    public void WithArgs_UsesAsyncArgsSignature()
     {
         var code = ScriptCommands.BuildEvalCode("args[0]", [], hasArgs: true);
 
-        Assert.Contains("public static object Main(string[] args)", code);
+        // Async-by-default: agents can write `await ...` directly in eval.
+        Assert.Contains("public static async System.Threading.Tasks.Task<object> Main(string[] args)", code);
     }
 
     [Fact]
-    public void WithoutArgs_UsesParameterlessSignature()
+    public void WithoutArgs_UsesAsyncParameterlessSignature()
     {
         var code = ScriptCommands.BuildEvalCode("1", [], hasArgs: false);
 
-        Assert.Contains("public static object Main()", code);
+        Assert.Contains("public static async System.Threading.Tasks.Task<object> Main()", code);
         Assert.DoesNotContain("string[] args", code);
     }
 
@@ -77,7 +78,20 @@ public class EvalCodeGeneratorTests
         var code = ScriptCommands.BuildEvalCode("Application.version", [], hasArgs: false);
 
         Assert.Contains("public class Script", code);
-        Assert.Contains("public static object Main()", code);
+        Assert.Contains("public static async System.Threading.Tasks.Task<object> Main()", code);
+    }
+
+    [Fact]
+    public void AsyncWrapper_AllowsAwaitInExpression()
+    {
+        // The whole point of async-by-default: this expression must end up
+        // inside an async method so the `await` compiles. Before this change,
+        // bare `await` produced CS4032.
+        var code = ScriptCommands.BuildEvalCode(
+            "await System.Threading.Tasks.Task.Delay(10); return 42;", [], hasArgs: false);
+
+        Assert.Contains("async System.Threading.Tasks.Task<object> Main", code);
+        Assert.Contains("await System.Threading.Tasks.Task.Delay(10);", code);
     }
 
     [Fact]
@@ -513,7 +527,7 @@ public class EvalCodeGeneratorTests
         Assert.Contains("using Dirtybit.Game.Model;", code);
         Assert.Contains("using UnityEngine.SceneManagement;", code);
         // … and the body should no longer have inline `using` statements.
-        var mainBodyStart = code.IndexOf("public static object Main()", StringComparison.Ordinal);
+        var mainBodyStart = code.IndexOf("Task<object> Main()", StringComparison.Ordinal);
         var mainBody = code.Substring(mainBodyStart);
         Assert.DoesNotContain("using Dirtybit.Game.Model;", mainBody);
         Assert.DoesNotContain("using UnityEngine.SceneManagement;", mainBody);

--- a/UnityCtl.Tests/Unit/UnityPackage/AsyncUnwrapTests.cs
+++ b/UnityCtl.Tests/Unit/UnityPackage/AsyncUnwrapTests.cs
@@ -75,7 +75,7 @@ public class AsyncUnwrapTests
     [Fact]
     public async Task DeeplyNestedTaskAtDepthCap_UnwrapsAllLayers()
     {
-        // Four wrap layers — within the cap of 4.
+        // Four wrap layers — exactly at the cap of 4, must still succeed.
         var task = Task.FromResult<object>(
             Task.FromResult<object>(
                 Task.FromResult<object>(

--- a/UnityCtl.Tests/Unit/UnityPackage/AsyncUnwrapTests.cs
+++ b/UnityCtl.Tests/Unit/UnityPackage/AsyncUnwrapTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Threading.Tasks;
+using UnityCtl.Editor;
+using Xunit;
+
+namespace UnityCtl.Tests.Unit.UnityPackage;
+
+public class AsyncUnwrapTests
+{
+    [Fact]
+    public async Task NonTaskValue_ReturnedAsIs()
+    {
+        var result = await AsyncUnwrap.UnwrapAsync(42, declaredReturnType: typeof(object), maxDepth: 4);
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public async Task NullValue_ReturnedAsNull()
+    {
+        var result = await AsyncUnwrap.UnwrapAsync(null, declaredReturnType: typeof(object), maxDepth: 4);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task TaskOfInt_FromResult_Unwraps()
+    {
+        var task = Task.FromResult(99);
+        var result = await AsyncUnwrap.UnwrapAsync(task, declaredReturnType: typeof(Task<int>), maxDepth: 4);
+        Assert.Equal(99, result);
+    }
+
+    [Fact]
+    public async Task TaskOfString_RealAwait_Unwraps()
+    {
+        async Task<string> Inner() { await Task.Delay(5); return "ok"; }
+        var task = Inner();
+        var result = await AsyncUnwrap.UnwrapAsync(task, declaredReturnType: typeof(Task<string>), maxDepth: 4);
+        Assert.Equal("ok", result);
+    }
+
+    [Fact]
+    public async Task NonGenericTask_DeclaredVoid_ReturnsNull()
+    {
+        // `async Task Main()` declares Task; runtime is Task<VoidTaskResult>.
+        // Declared-type hint at depth 0 makes the void detection robust without
+        // depending on the internal sentinel name.
+        async Task Inner() { await Task.Delay(5); }
+        Task task = Inner();
+        var result = await AsyncUnwrap.UnwrapAsync(task, declaredReturnType: typeof(Task), maxDepth: 4);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task NonGenericTask_NoDeclaredType_VoidTaskResultFallback()
+    {
+        // No declared-type hint — fall back to the runtime VoidTaskResult check
+        // so the helper still does the right thing if a caller forgets to plumb
+        // the declared type through.
+        async Task Inner() { await Task.Delay(5); }
+        Task task = Inner();
+        var result = await AsyncUnwrap.UnwrapAsync(task, declaredReturnType: null, maxDepth: 4);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task NestedTaskOfTaskOfInt_UnwrapsToInner()
+    {
+        // Agent writes `return Task.FromResult(42);` inside an async Main —
+        // the return is Task<object> wrapping Task<int>.
+        var task = Task.FromResult<object>(Task.FromResult(42));
+        var result = await AsyncUnwrap.UnwrapAsync(task, declaredReturnType: typeof(Task<object>), maxDepth: 4);
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public async Task DeeplyNestedTaskAtDepthCap_UnwrapsAllLayers()
+    {
+        // Four wrap layers — within the cap of 4.
+        var task = Task.FromResult<object>(
+            Task.FromResult<object>(
+                Task.FromResult<object>(
+                    Task.FromResult(7))));
+        var result = await AsyncUnwrap.UnwrapAsync(task, declaredReturnType: typeof(Task<object>), maxDepth: 4);
+        Assert.Equal(7, result);
+    }
+
+    [Fact]
+    public async Task DeeplyNestedTaskBeyondCap_ThrowsClearError()
+    {
+        // Five wrap layers — exceeds the cap. Must throw, not silently leave
+        // a Task in the result (which would re-introduce the wedge bug if
+        // Newtonsoft serialised it reflectively).
+        var task = Task.FromResult<object>(
+            Task.FromResult<object>(
+                Task.FromResult<object>(
+                    Task.FromResult<object>(
+                        Task.FromResult(7)))));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await AsyncUnwrap.UnwrapAsync(task, declaredReturnType: typeof(Task<object>), maxDepth: 4));
+        Assert.Contains("4", ex.Message);
+    }
+
+    [Fact]
+    public async Task FaultedTask_PropagatesInnerException()
+    {
+        async Task<int> Boom() { await Task.Delay(5); throw new InvalidOperationException("boom"); }
+        var task = Boom();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await AsyncUnwrap.UnwrapAsync(task, declaredReturnType: typeof(Task<int>), maxDepth: 4));
+        Assert.Equal("boom", ex.Message);
+    }
+}

--- a/UnityCtl.Tests/UnityCtl.Tests.csproj
+++ b/UnityCtl.Tests/UnityCtl.Tests.csproj
@@ -31,6 +31,8 @@
   <ItemGroup>
     <!-- Link the Unity-side TypeResolver so we can unit-test its pure logic outside Unity. -->
     <Compile Include="..\UnityCtl.UnityPackage\Editor\TypeResolver.cs" Link="LinkedFromUnityPackage\TypeResolver.cs" />
+    <!-- Same trick for AsyncUnwrap — pure .NET, no Unity refs, testable outside Unity. -->
+    <Compile Include="..\UnityCtl.UnityPackage\Editor\AsyncUnwrap.cs" Link="LinkedFromUnityPackage\AsyncUnwrap.cs" />
   </ItemGroup>
 
 </Project>

--- a/UnityCtl.UnityPackage/Editor/AsyncUnwrap.cs
+++ b/UnityCtl.UnityPackage/Editor/AsyncUnwrap.cs
@@ -12,24 +12,21 @@ namespace UnityCtl.Editor
     /// </summary>
     public static class AsyncUnwrap
     {
-        // Internal sentinel from the compiler-generated builder for
-        // `async Task` methods — the runtime type is actually
-        // `Task<VoidTaskResult>`. Used as a fallback when the caller does not
-        // provide a declared return type.
+        // Compiler-generated builder for `async Task` methods returns a
+        // runtime type of `Task<VoidTaskResult>` — that internal type isn't
+        // public, so we match by full name.
         private const string VoidTaskResultFullName = "System.Threading.Tasks.VoidTaskResult";
 
         /// <summary>
         /// If <paramref name="value"/> is a <c>Task</c> or <c>Task&lt;T&gt;</c>,
         /// awaits and returns the inner value. Repeats for nested Tasks
-        /// (e.g. an agent who returns <c>Task.FromResult(x)</c> from inside an
-        /// async method, boxing a <c>Task&lt;T&gt;</c> through the outer
-        /// <c>Task&lt;object&gt;</c>).
+        /// (e.g. <c>return Task.FromResult(x);</c> inside an async Main, which
+        /// boxes a <c>Task&lt;T&gt;</c> through the outer <c>Task&lt;object&gt;</c>).
         ///
-        /// <paramref name="declaredReturnType"/> is the user method's declared
-        /// return type — used at depth 0 to distinguish <c>async Task</c>
+        /// <paramref name="declaredReturnType"/> distinguishes <c>async Task</c>
         /// (declared <c>Task</c>, runtime <c>Task&lt;VoidTaskResult&gt;</c>)
-        /// from <c>async Task&lt;T&gt;</c> reliably, without depending on the
-        /// internal <c>VoidTaskResult</c> type name.
+        /// from <c>async Task&lt;T&gt;</c> at the outermost layer reliably,
+        /// without depending on the internal sentinel type.
         /// </summary>
         /// <exception cref="InvalidOperationException">
         /// Thrown when the unwrap depth exceeds <paramref name="maxDepth"/>.
@@ -39,9 +36,18 @@ namespace UnityCtl.Editor
         /// pre-async-by-default wedge bug if the inner Task is pending and
         /// needs the main thread.
         /// </exception>
-        public static async Task<object?> UnwrapAsync(object? value, Type? declaredReturnType, int maxDepth)
+        public static async Task<object?> UnwrapAsync(
+            object? value, Type? declaredReturnType, int maxDepth = 4)
         {
-            for (var depth = 0; value is Task t; depth++)
+            if (value is not Task outer) return value;
+
+            await outer;
+            value = ReadResult(outer, declaredReturnType);
+
+            // Inner layers are rare (only nested Task.FromResult chains), so
+            // we always use the runtime-type walk past the outermost. depth
+            // starts at 1 because the outer was just consumed.
+            for (var depth = 1; value is Task inner; depth++)
             {
                 if (depth >= maxDepth)
                 {
@@ -49,50 +55,41 @@ namespace UnityCtl.Editor
                         $"Task unwrap depth exceeded {maxDepth} — return Task chain too deeply nested. " +
                         $"Did you mean to `await` an inner Task before returning?");
                 }
-
-                await t;
-
-                // Pick the Task<T> we read .Result from. At depth 0 the user's
-                // declared return type is the most reliable hint — declared
-                // `Task` (non-generic) means void, even though the runtime
-                // type is Task<VoidTaskResult>.
-                Type? generic = null;
-                if (depth == 0 && declaredReturnType != null)
-                {
-                    if (declaredReturnType == typeof(Task))
-                        return null;
-                    if (declaredReturnType.IsGenericType
-                        && declaredReturnType.GetGenericTypeDefinition() == typeof(Task<>))
-                        generic = declaredReturnType;
-                }
-
-                // Inner layers (or no declared-type hint) — walk the runtime
-                // type chain to find a Task<T> ancestor.
-                if (generic == null)
-                {
-                    generic = t.GetType();
-                    while (generic != null
-                           && !(generic.IsGenericType && generic.GetGenericTypeDefinition() == typeof(Task<>)))
-                        generic = generic.BaseType;
-                }
-
-                if (generic == null)
-                {
-                    // Non-generic Task with no declared-type hint — void.
-                    return null;
-                }
-
-                // Compiler-generated `async Task` builder produces the
-                // VoidTaskResult sentinel; treat as void if we landed here
-                // without a declared-type hint to do it earlier.
-                var arg = generic.GetGenericArguments()[0];
-                if (arg.FullName == VoidTaskResultFullName)
-                    return null;
-
-                value = generic.GetProperty("Result")!.GetValue(t);
+                await inner;
+                value = ReadResult(inner, declaredReturnType: null);
             }
 
             return value;
+        }
+
+        // Extract the value from a Task. At the outermost layer the user's
+        // declared return type is the most reliable signal for void; inner
+        // layers fall back to walking the runtime type chain.
+        private static object? ReadResult(Task task, Type? declaredReturnType)
+        {
+            if (declaredReturnType == typeof(Task))
+                return null;
+
+            Type? generic = null;
+            if (declaredReturnType is { IsGenericType: true } d
+                && d.GetGenericTypeDefinition() == typeof(Task<>))
+            {
+                generic = d;
+            }
+            else
+            {
+                generic = task.GetType();
+                while (generic != null
+                       && !(generic.IsGenericType && generic.GetGenericTypeDefinition() == typeof(Task<>)))
+                    generic = generic.BaseType;
+            }
+
+            if (generic == null) return null;
+
+            var arg = generic.GetGenericArguments()[0];
+            if (arg.FullName == VoidTaskResultFullName) return null;
+
+            return generic.GetProperty("Result")!.GetValue(task);
         }
     }
 }

--- a/UnityCtl.UnityPackage/Editor/AsyncUnwrap.cs
+++ b/UnityCtl.UnityPackage/Editor/AsyncUnwrap.cs
@@ -1,0 +1,98 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+
+namespace UnityCtl.Editor
+{
+    /// <summary>
+    /// Unwrap a <see cref="Task"/> or <see cref="Task{T}"/> return value into
+    /// the inner result. Pure .NET, no Unity references — linked into the
+    /// test project so the unwrap rules can be tested without spinning up an
+    /// editor.
+    /// </summary>
+    public static class AsyncUnwrap
+    {
+        // Internal sentinel from the compiler-generated builder for
+        // `async Task` methods — the runtime type is actually
+        // `Task<VoidTaskResult>`. Used as a fallback when the caller does not
+        // provide a declared return type.
+        private const string VoidTaskResultFullName = "System.Threading.Tasks.VoidTaskResult";
+
+        /// <summary>
+        /// If <paramref name="value"/> is a <c>Task</c> or <c>Task&lt;T&gt;</c>,
+        /// awaits and returns the inner value. Repeats for nested Tasks
+        /// (e.g. an agent who returns <c>Task.FromResult(x)</c> from inside an
+        /// async method, boxing a <c>Task&lt;T&gt;</c> through the outer
+        /// <c>Task&lt;object&gt;</c>).
+        ///
+        /// <paramref name="declaredReturnType"/> is the user method's declared
+        /// return type — used at depth 0 to distinguish <c>async Task</c>
+        /// (declared <c>Task</c>, runtime <c>Task&lt;VoidTaskResult&gt;</c>)
+        /// from <c>async Task&lt;T&gt;</c> reliably, without depending on the
+        /// internal <c>VoidTaskResult</c> type name.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the unwrap depth exceeds <paramref name="maxDepth"/>.
+        /// Without this guard, returning a still-Task value would silently
+        /// hand it to JSON serialisation, which reflects over the Task's
+        /// public properties (including <c>.Result</c>) and re-introduces the
+        /// pre-async-by-default wedge bug if the inner Task is pending and
+        /// needs the main thread.
+        /// </exception>
+        public static async Task<object?> UnwrapAsync(object? value, Type? declaredReturnType, int maxDepth)
+        {
+            for (var depth = 0; value is Task t; depth++)
+            {
+                if (depth >= maxDepth)
+                {
+                    throw new InvalidOperationException(
+                        $"Task unwrap depth exceeded {maxDepth} — return Task chain too deeply nested. " +
+                        $"Did you mean to `await` an inner Task before returning?");
+                }
+
+                await t;
+
+                // Pick the Task<T> we read .Result from. At depth 0 the user's
+                // declared return type is the most reliable hint — declared
+                // `Task` (non-generic) means void, even though the runtime
+                // type is Task<VoidTaskResult>.
+                Type? generic = null;
+                if (depth == 0 && declaredReturnType != null)
+                {
+                    if (declaredReturnType == typeof(Task))
+                        return null;
+                    if (declaredReturnType.IsGenericType
+                        && declaredReturnType.GetGenericTypeDefinition() == typeof(Task<>))
+                        generic = declaredReturnType;
+                }
+
+                // Inner layers (or no declared-type hint) — walk the runtime
+                // type chain to find a Task<T> ancestor.
+                if (generic == null)
+                {
+                    generic = t.GetType();
+                    while (generic != null
+                           && !(generic.IsGenericType && generic.GetGenericTypeDefinition() == typeof(Task<>)))
+                        generic = generic.BaseType;
+                }
+
+                if (generic == null)
+                {
+                    // Non-generic Task with no declared-type hint — void.
+                    return null;
+                }
+
+                // Compiler-generated `async Task` builder produces the
+                // VoidTaskResult sentinel; treat as void if we landed here
+                // without a declared-type hint to do it earlier.
+                var arg = generic.GetGenericArguments()[0];
+                if (arg.FullName == VoidTaskResultFullName)
+                    return null;
+
+                value = generic.GetProperty("Result")!.GetValue(t);
+            }
+
+            return value;
+        }
+    }
+}

--- a/UnityCtl.UnityPackage/Editor/AsyncUnwrap.cs.meta
+++ b/UnityCtl.UnityPackage/Editor/AsyncUnwrap.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f096ea457f557f64587c1fec11d449d0

--- a/UnityCtl.UnityPackage/Editor/ScriptExecutor.cs
+++ b/UnityCtl.UnityPackage/Editor/ScriptExecutor.cs
@@ -59,41 +59,26 @@ namespace UnityCtl.Editor
             }
         }
 
-        // Cap on how many layers of nested Task<Task<...>> we will unwrap.
-        // 4 covers any realistic agent expression — `return Task.FromResult(x)`
-        // inside an async Main is the only non-pathological way to nest, and
-        // that's depth 2 (outer async Task<object> wrapping the inner Task<T>).
-        // Beyond the cap we throw rather than handing a still-Task value to
-        // JSON serialisation, which would re-introduce the wedge bug if
-        // Newtonsoft reflected over `.Result` on a pending main-thread-bound
-        // Task.
-        const int MaxUnwrapDepth = 4;
-
         /// <summary>
         /// Async-aware script entry. If <c>Main</c> returns a <c>Task</c> or
         /// <c>Task&lt;T&gt;</c>, this awaits and unwraps before serialising.
-        /// All result serialisation is centralised here so the rule "the
-        /// string in <see cref="ScriptExecuteResult.Result"/> is the JSON
-        /// view of whatever the user ultimately returned" holds for every
-        /// path.
+        /// All result serialisation lives here so the wire shape of
+        /// <see cref="ScriptExecuteResult.Result"/> is built in one place.
         ///
-        /// The await captures the caller's <see cref="System.Threading.SynchronizationContext"/>,
-        /// so when invoked from Unity's main thread the continuation
-        /// (and serialisation) resume on the main thread — safe for Unity-type
-        /// JSON output. Callers that want the main thread freed during the
-        /// await should invoke this from a fire-and-forget Task so the
-        /// Pump tick releases the main thread immediately.
+        /// The await captures Unity's main-thread <see cref="System.Threading.SynchronizationContext"/>,
+        /// so the continuation (and serialisation) resume on the main thread —
+        /// safe for Unity-type JSON output. Callers that want the main thread
+        /// freed during the await invoke this from a fire-and-forget Task so
+        /// the Pump tick releases the main thread immediately.
         /// </summary>
         public static async Task<ScriptExecuteResult> ExecuteAsync(string code, string className, string methodName, string[]? scriptArgs = null)
         {
-            var result = Execute(code, className, methodName, scriptArgs);
+            var (result, raw, declared) = Compile(code, className, methodName, scriptArgs);
             if (!result.Success) return result;
 
             try
             {
-                var value = await AsyncUnwrap.UnwrapAsync(
-                    result.RawReturn, result.DeclaredReturnType, MaxUnwrapDepth);
-                result.RawReturn = value;
+                var value = await AsyncUnwrap.UnwrapAsync(raw, declared);
                 result.Result = SerializeReturn(value);
                 return result;
             }
@@ -117,39 +102,20 @@ namespace UnityCtl.Editor
             catch { return value.ToString(); }
         }
 
-        // Compile + invoke the user's Main. Internal — callers should use
-        // ExecuteAsync, which is the only path that handles Task returns
-        // correctly. Kept as a separate method so the (sync) Roslyn work and
-        // the (async) Task-unwrap responsibilities live in obviously
-        // separate functions.
-        static ScriptExecuteResult Execute(string code, string className, string methodName, string[]? scriptArgs = null)
+        // Compile + invoke the user's Main. Returns the success/error
+        // shell along with the raw return object and the method's
+        // declared return type — both needed by ExecuteAsync to decide
+        // whether to await/unwrap. Private so callers can't accidentally
+        // bypass the unwrap step.
+        static (ScriptExecuteResult Result, object? Raw, Type? Declared) Compile(
+            string code, string className, string methodName, string[]? scriptArgs = null)
         {
             if (string.IsNullOrEmpty(code))
-            {
-                return new ScriptExecuteResult
-                {
-                    Success = false,
-                    Error = "Code cannot be null or empty."
-                };
-            }
-
+                return (Failure("Code cannot be null or empty."), null, null);
             if (string.IsNullOrEmpty(className))
-            {
-                return new ScriptExecuteResult
-                {
-                    Success = false,
-                    Error = "Class name cannot be null or empty."
-                };
-            }
-
+                return (Failure("Class name cannot be null or empty."), null, null);
             if (string.IsNullOrEmpty(methodName))
-            {
-                return new ScriptExecuteResult
-                {
-                    Success = false,
-                    Error = "Method name cannot be null or empty."
-                };
-            }
+                return (Failure("Method name cannot be null or empty."), null, null);
 
             var profile = Environment.GetEnvironmentVariable("UNITYCTL_SCRIPT_PROFILE") == "1";
             var refSw = profile ? Stopwatch.StartNew() : null;
@@ -193,13 +159,13 @@ namespace UnityCtl.Editor
 
                     var hints = TypeResolver.BuildHints(diagnostics);
 
-                    return new ScriptExecuteResult
+                    return (new ScriptExecuteResult
                     {
                         Success = false,
                         Error = "Compilation failed.",
                         Diagnostics = diagnostics,
                         Hints = hints.Length > 0 ? hints : null
-                    };
+                    }, null, null);
                 }
 
                 // Load the assembly
@@ -209,13 +175,7 @@ namespace UnityCtl.Editor
                 // Find the type
                 var type = assembly.GetType(className);
                 if (type == null)
-                {
-                    return new ScriptExecuteResult
-                    {
-                        Success = false,
-                        Error = $"Class '{className}' not found in compiled assembly."
-                    };
-                }
+                    return (Failure($"Class '{className}' not found in compiled assembly."), null, null);
 
                 // Find the method - try with string[] parameter first, then parameterless
                 var methodWithArgs = type.GetMethod(methodName,
@@ -240,59 +200,38 @@ namespace UnityCtl.Editor
                 }
                 else
                 {
-                    return new ScriptExecuteResult
-                    {
-                        Success = false,
-                        Error = $"Static method '{methodName}' not found in class '{className}'. Expected '{methodName}()' or '{methodName}(string[] args)'."
-                    };
+                    return (Failure(
+                        $"Static method '{methodName}' not found in class '{className}'. " +
+                        $"Expected '{methodName}()' or '{methodName}(string[] args)'."), null, null);
                 }
 
-                // Invoke the method
-                object? result;
+                object? raw;
                 try
                 {
-                    result = method.Invoke(null, invokeArgs);
+                    raw = method.Invoke(null, invokeArgs);
                 }
                 catch (TargetInvocationException ex)
                 {
                     var inner = ex.InnerException ?? ex;
-                    return new ScriptExecuteResult
-                    {
-                        Success = false,
-                        Error = $"Runtime error: {inner.Message}\n{inner.StackTrace}"
-                    };
+                    return (Failure($"Runtime error: {inner.Message}\n{inner.StackTrace}"), null, null);
                 }
 
-                // Stash the raw return + declared return type for ExecuteAsync.
-                // The declared type lets the unwrapper distinguish `async Task`
-                // (declared Task, runtime Task<VoidTaskResult>) from
-                // `async Task<T>` without depending on the internal sentinel
-                // type name. ExecuteAsync owns serialisation — keeping it in
-                // one place ensures one rule for what the wire result looks
-                // like.
-                return new ScriptExecuteResult
-                {
-                    Success = true,
-                    RawReturn = result,
-                    DeclaredReturnType = method.ReturnType
-                };
+                return (new ScriptExecuteResult { Success = true }, raw, method.ReturnType);
             }
             catch (Exception ex)
             {
-                // Unwrap inner exceptions to get the real error
                 var innerMsg = ex.InnerException != null
                     ? $"\nInner: {ex.InnerException.Message}\n{ex.InnerException.StackTrace}"
                     : "";
                 var inner2Msg = ex.InnerException?.InnerException != null
                     ? $"\nInner2: {ex.InnerException.InnerException.Message}"
                     : "";
-                return new ScriptExecuteResult
-                {
-                    Success = false,
-                    Error = $"Unexpected error: {ex.Message}{innerMsg}{inner2Msg}\n{ex.StackTrace}"
-                };
+                return (Failure($"Unexpected error: {ex.Message}{innerMsg}{inner2Msg}\n{ex.StackTrace}"), null, null);
             }
         }
+
+        static ScriptExecuteResult Failure(string error) =>
+            new ScriptExecuteResult { Success = false, Error = error };
     }
 
     public class ScriptExecuteResult
@@ -302,23 +241,5 @@ namespace UnityCtl.Editor
         public string? Error { get; set; }
         public string[]? Diagnostics { get; set; }
         public string[]? Hints { get; set; }
-
-        /// <summary>
-        /// Raw object returned by the user's Main method, before JSON
-        /// serialisation. Used by <see cref="ScriptExecutor.ExecuteAsync"/> to
-        /// detect a <c>Task</c>/<c>Task&lt;T&gt;</c> return so it can await
-        /// and unwrap. Not transmitted over the wire.
-        /// </summary>
-        [JsonIgnore]
-        public object? RawReturn { get; set; }
-
-        /// <summary>
-        /// Declared return type of the user's Main method. Lets the unwrapper
-        /// distinguish <c>async Task</c> (declared <c>Task</c>, runtime
-        /// <c>Task&lt;VoidTaskResult&gt;</c>) from <c>async Task&lt;T&gt;</c>.
-        /// Not transmitted over the wire.
-        /// </summary>
-        [JsonIgnore]
-        public Type? DeclaredReturnType { get; set; }
     }
 }

--- a/UnityCtl.UnityPackage/Editor/ScriptExecutor.cs
+++ b/UnityCtl.UnityPackage/Editor/ScriptExecutor.cs
@@ -84,13 +84,12 @@ namespace UnityCtl.Editor
             }
             catch (Exception ex)
             {
-                var inner = ex is AggregateException agg && agg.InnerException != null
-                    ? agg.InnerException
-                    : ex;
+                // `await` already rethrows the first inner exception from a
+                // faulted Task, so we don't need an AggregateException unwrap.
                 return new ScriptExecuteResult
                 {
                     Success = false,
-                    Error = $"Runtime error: {inner.Message}\n{inner.StackTrace}"
+                    Error = $"Runtime error: {ex.Message}\n{ex.StackTrace}"
                 };
             }
         }

--- a/UnityCtl.UnityPackage/Editor/ScriptExecutor.cs
+++ b/UnityCtl.UnityPackage/Editor/ScriptExecutor.cs
@@ -59,72 +59,55 @@ namespace UnityCtl.Editor
             }
         }
 
+        // Cap on how many layers of nested Task<Task<...>> we will unwrap.
+        // 4 covers any realistic agent expression — `return Task.FromResult(x)`
+        // inside an async Main is the only non-pathological way to nest, and
+        // that's depth 2 (outer async Task<object> wrapping the inner Task<T>).
+        // Beyond the cap we throw rather than handing a still-Task value to
+        // JSON serialisation, which would re-introduce the wedge bug if
+        // Newtonsoft reflected over `.Result` on a pending main-thread-bound
+        // Task.
+        const int MaxUnwrapDepth = 4;
+
         /// <summary>
         /// Async-aware script entry. If <c>Main</c> returns a <c>Task</c> or
-        /// <c>Task&lt;T&gt;</c>, this awaits it (unwrapping the value) before
-        /// serialising the result. Other return types are passed through.
+        /// <c>Task&lt;T&gt;</c>, this awaits and unwraps before serialising.
+        /// All result serialisation is centralised here so the rule "the
+        /// string in <see cref="ScriptExecuteResult.Result"/> is the JSON
+        /// view of whatever the user ultimately returned" holds for every
+        /// path.
         ///
-        /// The await happens on the calling thread's SynchronizationContext —
-        /// callers that want the main thread freed during the await should
-        /// invoke this from an async context (a fire-and-forget Task that
-        /// the Pump tick can release).
+        /// The await captures the caller's <see cref="System.Threading.SynchronizationContext"/>,
+        /// so when invoked from Unity's main thread the continuation
+        /// (and serialisation) resume on the main thread — safe for Unity-type
+        /// JSON output. Callers that want the main thread freed during the
+        /// await should invoke this from a fire-and-forget Task so the
+        /// Pump tick releases the main thread immediately.
         /// </summary>
         public static async Task<ScriptExecuteResult> ExecuteAsync(string code, string className, string methodName, string[]? scriptArgs = null)
         {
             var result = Execute(code, className, methodName, scriptArgs);
+            if (!result.Success) return result;
 
-            // Successful sync invoke that produced a Task → await and unwrap.
-            // Loop in case the unwrapped value is itself a Task (e.g. an agent
-            // wrote `return Task.FromResult(42);` inside an async Main, which
-            // boxes the inner Task<int> through the outer Task<object>). Cap
-            // at a small depth so a pathological nested return can't spin.
-            if (result.Success && result.RawReturn is Task)
+            try
             {
-                try
-                {
-                    object? value = result.RawReturn;
-                    for (var depth = 0; depth < 4 && value is Task t; depth++)
-                    {
-                        await t;
-                        // `async Task Main()` actually returns the runtime
-                        // type Task<VoidTaskResult> — IsGenericType is true,
-                        // but the inner value is a sentinel struct we must
-                        // treat as void. Walk up to find a Task<T> ancestor;
-                        // if T is VoidTaskResult, the user wanted void.
-                        Type? generic = t.GetType();
-                        while (generic != null &&
-                               !(generic.IsGenericType && generic.GetGenericTypeDefinition() == typeof(Task<>)))
-                            generic = generic.BaseType;
-
-                        if (generic != null)
-                        {
-                            var arg = generic.GetGenericArguments()[0];
-                            value = arg.FullName == "System.Threading.Tasks.VoidTaskResult"
-                                ? null
-                                : generic.GetProperty("Result")!.GetValue(t);
-                        }
-                        else
-                        {
-                            value = null;
-                        }
-                    }
-                    result.RawReturn = value;
-                    result.Result = SerializeReturn(value);
-                }
-                catch (Exception ex)
-                {
-                    var inner = ex is AggregateException agg && agg.InnerException != null
-                        ? agg.InnerException
-                        : ex;
-                    return new ScriptExecuteResult
-                    {
-                        Success = false,
-                        Error = $"Runtime error: {inner.Message}\n{inner.StackTrace}"
-                    };
-                }
+                var value = await AsyncUnwrap.UnwrapAsync(
+                    result.RawReturn, result.DeclaredReturnType, MaxUnwrapDepth);
+                result.RawReturn = value;
+                result.Result = SerializeReturn(value);
+                return result;
             }
-
-            return result;
+            catch (Exception ex)
+            {
+                var inner = ex is AggregateException agg && agg.InnerException != null
+                    ? agg.InnerException
+                    : ex;
+                return new ScriptExecuteResult
+                {
+                    Success = false,
+                    Error = $"Runtime error: {inner.Message}\n{inner.StackTrace}"
+                };
+            }
         }
 
         static string? SerializeReturn(object? value)
@@ -134,7 +117,12 @@ namespace UnityCtl.Editor
             catch { return value.ToString(); }
         }
 
-        public static ScriptExecuteResult Execute(string code, string className, string methodName, string[]? scriptArgs = null)
+        // Compile + invoke the user's Main. Internal — callers should use
+        // ExecuteAsync, which is the only path that handles Task returns
+        // correctly. Kept as a separate method so the (sync) Roslyn work and
+        // the (async) Task-unwrap responsibilities live in obviously
+        // separate functions.
+        static ScriptExecuteResult Execute(string code, string className, string methodName, string[]? scriptArgs = null)
         {
             if (string.IsNullOrEmpty(code))
             {
@@ -275,15 +263,18 @@ namespace UnityCtl.Editor
                     };
                 }
 
-                // Serialize the result. RawReturn is preserved so ExecuteAsync
-                // can detect a Task return and await/unwrap it before
-                // serialisation. Non-Task returns are serialised eagerly here
-                // so the existing sync API is unchanged.
+                // Stash the raw return + declared return type for ExecuteAsync.
+                // The declared type lets the unwrapper distinguish `async Task`
+                // (declared Task, runtime Task<VoidTaskResult>) from
+                // `async Task<T>` without depending on the internal sentinel
+                // type name. ExecuteAsync owns serialisation — keeping it in
+                // one place ensures one rule for what the wire result looks
+                // like.
                 return new ScriptExecuteResult
                 {
                     Success = true,
                     RawReturn = result,
-                    Result = result is Task ? null : SerializeReturn(result)
+                    DeclaredReturnType = method.ReturnType
                 };
             }
             catch (Exception ex)
@@ -320,5 +311,14 @@ namespace UnityCtl.Editor
         /// </summary>
         [JsonIgnore]
         public object? RawReturn { get; set; }
+
+        /// <summary>
+        /// Declared return type of the user's Main method. Lets the unwrapper
+        /// distinguish <c>async Task</c> (declared <c>Task</c>, runtime
+        /// <c>Task&lt;VoidTaskResult&gt;</c>) from <c>async Task&lt;T&gt;</c>.
+        /// Not transmitted over the wire.
+        /// </summary>
+        [JsonIgnore]
+        public Type? DeclaredReturnType { get; set; }
     }
 }

--- a/UnityCtl.UnityPackage/Editor/ScriptExecutor.cs
+++ b/UnityCtl.UnityPackage/Editor/ScriptExecutor.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Newtonsoft.Json;
@@ -56,6 +57,81 @@ namespace UnityCtl.Editor
                 s_References = refs;
                 return refs;
             }
+        }
+
+        /// <summary>
+        /// Async-aware script entry. If <c>Main</c> returns a <c>Task</c> or
+        /// <c>Task&lt;T&gt;</c>, this awaits it (unwrapping the value) before
+        /// serialising the result. Other return types are passed through.
+        ///
+        /// The await happens on the calling thread's SynchronizationContext —
+        /// callers that want the main thread freed during the await should
+        /// invoke this from an async context (a fire-and-forget Task that
+        /// the Pump tick can release).
+        /// </summary>
+        public static async Task<ScriptExecuteResult> ExecuteAsync(string code, string className, string methodName, string[]? scriptArgs = null)
+        {
+            var result = Execute(code, className, methodName, scriptArgs);
+
+            // Successful sync invoke that produced a Task → await and unwrap.
+            // Loop in case the unwrapped value is itself a Task (e.g. an agent
+            // wrote `return Task.FromResult(42);` inside an async Main, which
+            // boxes the inner Task<int> through the outer Task<object>). Cap
+            // at a small depth so a pathological nested return can't spin.
+            if (result.Success && result.RawReturn is Task)
+            {
+                try
+                {
+                    object? value = result.RawReturn;
+                    for (var depth = 0; depth < 4 && value is Task t; depth++)
+                    {
+                        await t;
+                        // `async Task Main()` actually returns the runtime
+                        // type Task<VoidTaskResult> — IsGenericType is true,
+                        // but the inner value is a sentinel struct we must
+                        // treat as void. Walk up to find a Task<T> ancestor;
+                        // if T is VoidTaskResult, the user wanted void.
+                        Type? generic = t.GetType();
+                        while (generic != null &&
+                               !(generic.IsGenericType && generic.GetGenericTypeDefinition() == typeof(Task<>)))
+                            generic = generic.BaseType;
+
+                        if (generic != null)
+                        {
+                            var arg = generic.GetGenericArguments()[0];
+                            value = arg.FullName == "System.Threading.Tasks.VoidTaskResult"
+                                ? null
+                                : generic.GetProperty("Result")!.GetValue(t);
+                        }
+                        else
+                        {
+                            value = null;
+                        }
+                    }
+                    result.RawReturn = value;
+                    result.Result = SerializeReturn(value);
+                }
+                catch (Exception ex)
+                {
+                    var inner = ex is AggregateException agg && agg.InnerException != null
+                        ? agg.InnerException
+                        : ex;
+                    return new ScriptExecuteResult
+                    {
+                        Success = false,
+                        Error = $"Runtime error: {inner.Message}\n{inner.StackTrace}"
+                    };
+                }
+            }
+
+            return result;
+        }
+
+        static string? SerializeReturn(object? value)
+        {
+            if (value == null) return null;
+            try { return JsonConvert.SerializeObject(value, Formatting.Indented); }
+            catch { return value.ToString(); }
         }
 
         public static ScriptExecuteResult Execute(string code, string className, string methodName, string[]? scriptArgs = null)
@@ -199,24 +275,15 @@ namespace UnityCtl.Editor
                     };
                 }
 
-                // Serialize the result
-                string? resultString = null;
-                if (result != null)
-                {
-                    try
-                    {
-                        resultString = JsonConvert.SerializeObject(result, Formatting.Indented);
-                    }
-                    catch
-                    {
-                        resultString = result.ToString();
-                    }
-                }
-
+                // Serialize the result. RawReturn is preserved so ExecuteAsync
+                // can detect a Task return and await/unwrap it before
+                // serialisation. Non-Task returns are serialised eagerly here
+                // so the existing sync API is unchanged.
                 return new ScriptExecuteResult
                 {
                     Success = true,
-                    Result = resultString
+                    RawReturn = result,
+                    Result = result is Task ? null : SerializeReturn(result)
                 };
             }
             catch (Exception ex)
@@ -244,5 +311,14 @@ namespace UnityCtl.Editor
         public string? Error { get; set; }
         public string[]? Diagnostics { get; set; }
         public string[]? Hints { get; set; }
+
+        /// <summary>
+        /// Raw object returned by the user's Main method, before JSON
+        /// serialisation. Used by <see cref="ScriptExecutor.ExecuteAsync"/> to
+        /// detect a <c>Task</c>/<c>Task&lt;T&gt;</c> return so it can await
+        /// and unwrap. Not transmitted over the wire.
+        /// </summary>
+        [JsonIgnore]
+        public object? RawReturn { get; set; }
     }
 }

--- a/UnityCtl.UnityPackage/Editor/UnityCtlClient.cs
+++ b/UnityCtl.UnityPackage/Editor/UnityCtlClient.cs
@@ -428,6 +428,15 @@ namespace UnityCtl
 
         private void HandleCommand(RequestMessage request)
         {
+            // Async dispatch: commands that may await user code run on a fire-and-
+            // forget Task so the Pump tick (and main thread) is freed during the
+            // await. Continuations resume on Unity's main-thread SyncContext.
+            if (request.Command == UnityCtlCommands.ScriptExecute)
+            {
+                _ = HandleScriptExecuteAsync(request);
+                return;
+            }
+
             try
             {
                 object result = null;
@@ -539,9 +548,7 @@ namespace UnityCtl
                         result = HandleScreenshotWindow(request);
                         break;
 
-                    case UnityCtlCommands.ScriptExecute:
-                        result = HandleScriptExecute(request);
-                        break;
+                    // ScriptExecute is dispatched async at the top of this method.
 
                     case UnityCtlCommands.ScriptLookupType:
                         result = HandleScriptLookupType(request);
@@ -1423,39 +1430,46 @@ namespace UnityCtl
             }
         }
 
-        private object HandleScriptExecute(RequestMessage request)
+        private async System.Threading.Tasks.Task HandleScriptExecuteAsync(RequestMessage request)
         {
-            var code = GetStringArgument(request, "code");
-            var className = GetStringArgument(request, "className") ?? "Script";
-            var methodName = GetStringArgument(request, "methodName") ?? "Main";
-            var scriptArgs = GetStringArrayArgument(request, "scriptArgs");
-
-            if (string.IsNullOrEmpty(code))
+            try
             {
-                throw new ArgumentException("C# code is required");
+                var code = GetStringArgument(request, "code");
+                var className = GetStringArgument(request, "className") ?? "Script";
+                var methodName = GetStringArgument(request, "methodName") ?? "Main";
+                var scriptArgs = GetStringArrayArgument(request, "scriptArgs");
+
+                if (string.IsNullOrEmpty(code))
+                {
+                    SendResponseError(request.RequestId, "command_failed", "C# code is required");
+                    return;
+                }
+
+                DebugLog($"[UnityCtl] Executing script: class={className}, method={methodName}, args={scriptArgs?.Length ?? 0}");
+
+                // ExecuteAsync returns to Unity's captured SyncContext after any
+                // user-code await, so serialisation runs back on the main thread.
+                var result = await Editor.ScriptExecutor.ExecuteAsync(code, className, methodName, scriptArgs);
+
+                if (result.Success)
+                    DebugLog($"[UnityCtl] Script executed successfully");
+                else
+                    DebugLogError($"[UnityCtl] Script execution failed: {result.Error}");
+
+                SendResponseOk(request.RequestId, new Protocol.ScriptExecuteResult
+                {
+                    Success = result.Success,
+                    Result = result.Result,
+                    Error = result.Error,
+                    Diagnostics = result.Diagnostics,
+                    Hints = result.Hints
+                });
             }
-
-            DebugLog($"[UnityCtl] Executing script: class={className}, method={methodName}, args={scriptArgs?.Length ?? 0}");
-
-            var result = Editor.ScriptExecutor.Execute(code, className, methodName, scriptArgs);
-
-            if (result.Success)
+            catch (Exception ex)
             {
-                DebugLog($"[UnityCtl] Script executed successfully");
+                DebugLogError($"[UnityCtl] Async script handler failed: {ex.Message}");
+                SendResponseError(request.RequestId, "command_failed", ex.Message);
             }
-            else
-            {
-                DebugLogError($"[UnityCtl] Script execution failed: {result.Error}");
-            }
-
-            return new Protocol.ScriptExecuteResult
-            {
-                Success = result.Success,
-                Result = result.Result,
-                Error = result.Error,
-                Diagnostics = result.Diagnostics,
-                Hints = result.Hints
-            };
         }
 
         private static int ClampLimit(int? requested, int defaultValue, int max)


### PR DESCRIPTION
## Summary

`script eval` and `script execute` now run as `async Task<object> Main()`. Agents can write `await ...` directly in eval expressions, and `Task<T>` returns are unwrapped before serialisation. While a script awaits, Unity's main thread is freed — other RPCs run in parallel instead of queueing behind it.

A thorough review of the previous behaviour (against `a2a6bbd`) surfaced three bad failure modes:

- `await` in eval failed to compile (CS4032).
- `async Task<int> Main()` permanently wedged the editor — Newtonsoft serialised the returned Task by reflecting `.Result`, blocking the main thread on a continuation that needed the main thread. Recovery required `taskkill`.
- A long sync wait (or a `.Wait()` deadlock) blocked every other unityctl command behind it.

All three are fixed.

## Changes

- **`UnityCtl.Cli/ScriptCommands.cs`** — `BuildEvalCode` emits `public static async System.Threading.Tasks.Task<object> Main()` (and the `string[] args` variant). All other wrapping rules (`return <expr>;`, body-mode detection, leading-using lift, instance-id preamble) unchanged.
- **`UnityCtl.UnityPackage/Editor/ScriptExecutor.cs`** — new `ExecuteAsync` runs the user's `Main`, then if the return is a `Task` or `Task<T>`, awaits and unwraps before JSON-serialising. Loops up to 4 times to defend against nested Task returns (`return Task.FromResult(42);` inside an async Main boxes a `Task<int>` through `Task<object>`). Plain object returns are unchanged. `async Task Main()` (non-generic) actually returns a runtime `Task<VoidTaskResult>` via the compiler-generated builder; we walk the type chain to find the `Task<T>` ancestor and treat the `VoidTaskResult` sentinel as void.
- **`UnityCtl.UnityPackage/Editor/UnityCtlClient.cs`** — `script.execute` is forked at the top of `HandleCommand` to a fire-and-forget `HandleScriptExecuteAsync`. The Pump tick returns immediately, so Unity's main thread is free during the user's awaited work. Continuations resume on the captured Unity SyncContext, so JSON serialisation runs on the main thread (safe for Unity types).
- **`UnityCtl.Cli/Resources/SKILL.md`** — new "Async / waiting on things" section documenting `await`, the supported waiter shapes, and the threading rule (Unity APIs main-thread-only, no `.Wait()`/`.Result`). Composed skill regenerated.

## Why fire-and-forget instead of awaiting in `Pump`?

`Pump()` is invoked synchronously from `EditorApplication.update`. Awaiting inside would hold the Pump tick open until the user's awaited Task completed, blocking Unity's editor loop entirely. Forking lets the Pump tick exit immediately while the script runs to completion at its own pace; the response is sent from the async continuation.

User-code awaits with default `ConfigureAwait` post continuations to Unity's `SynchronizationContext`, which Unity drains on the main thread. As long as the main thread doesn't block on `.Wait()`/`.Result` (which agents have no reason to write now that `await` works), no deadlock is possible.

## Verified live against Unity 6000.0.63f1

| Pattern | Before | After |
|---|---|---|
| `await Task.Delay(10); return 42;` in eval | CS4032 | Returns `42` |
| `async Task<int> Main()` returning 99 | Permanent editor wedge | Returns `99` |
| `return Task.FromResult(42);` from eval | `{"Result":42,"Status":5,...}` | Returns `42` |
| `async Task Main()` (side effects only) | (deadlock path) | `(void)`, side effect logged |
| Long await + parallel probe | Probe times out (queued behind) | Both succeed concurrently |
| Sync `1+1` | `2` | `2` (regression OK) |
| `Task.Run(() => Application.isPlaying)` | Throws main-thread guard | Throws main-thread guard (still correct) |
| `ConfigureAwait(false)` inner async with `.Result` | Works (escapes captured ctx) | Works |
| Throw after `await` | n/a (couldn't await) | Captured as `Runtime error: ...` |

## Dogfood

Three fresh `general-purpose` subagents, no context from this work, were given async-requiring tasks:

1. **Cooperative poll-with-timeout** for `Application.isPlaying` — one-shot, used `while + await Task.Delay(100)`.
2. **Bridge `AsyncOperation` -> `Task` and time it** (`Resources.UnloadUnusedAssets()` returns `AsyncOperation`, not `Task`) — one-shot first try, used `TaskCompletionSource` + `op.completed += _ => tcs.SetResult(true);` + `await tcs.Task`.
3. **Concurrent commands** — demonstrated the short probe ran in 3 s while the 5 s waiter was still in flight (instead of queueing). Note: there's a ~3 s floor per CLI invocation on Windows from .NET cold-start + bridge HTTP round-trip; the concurrency property is verifiable from the per-command durations, not the wall-clock total.

All three found the SKILL guidance sufficient. None wedged the editor.

## Test plan

- [x] `dotnet test` — 476/476 pass, including the new `AsyncUnwrap` suite (nested Task chains, declared-`Task`-but-runtime-`Task<VoidTaskResult>` void detection, faulted task propagation, depth-cap throw) and the updated eval-generator signature assertions.
- [x] Live battery against Unity 6000.0.63f1 (table above)
- [x] Three dogfooding subagents one-shot tasks requiring async patterns
- [x] Editor never wedged during testing of the new code path (the previous-design review required two `taskkill` recoveries)
- [x] Depth-cap behaviour: at the cap (4 wraps) the helper unwraps cleanly; beyond the cap it throws `InvalidOperationException` with a clear "did you mean to await an inner Task?" message rather than silently leaking a `Task` to JSON serialisation. Asserted by `DeeplyNestedTaskAtDepthCap_UnwrapsAllLayers` and `DeeplyNestedTaskBeyondCap_ThrowsClearError`.
- [ ] Reviewer sanity-check: serialisation runs on the main thread (after the async continuation resumes via captured Unity SyncContext). If a future agent introduces a CPU-heavy serialisation path it would block the main thread for that duration. Today's JSON output for game state is small enough that it's a non-issue, but worth noting.